### PR TITLE
Entity 내 검증 로직 추가.

### DIFF
--- a/src/main/java/com/se/apiserver/v1/lectureroom/application/error/LectureRoomErrorCode.java
+++ b/src/main/java/com/se/apiserver/v1/lectureroom/application/error/LectureRoomErrorCode.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 public enum LectureRoomErrorCode implements ErrorCode {
 
   NO_SUCH_LECTURE_ROOM(400, "LRE01", "존재하지 않는 강의실"),
-  DUPLICATED_LECTURE_ROOM(401, "LRE02", "강의실 중복");
+  DUPLICATED_LECTURE_ROOM(401, "LRE02", "강의실 중복"),
+  INVALID_CAPACITY(402, "LRE03", "유효하지 않은 정원");
 
   private final int status;
   private final String code;

--- a/src/main/java/com/se/apiserver/v1/lectureroom/domain/entity/LectureRoom.java
+++ b/src/main/java/com/se/apiserver/v1/lectureroom/domain/entity/LectureRoom.java
@@ -2,6 +2,8 @@ package com.se.apiserver.v1.lectureroom.domain.entity;
 
 import com.se.apiserver.v1.common.domain.entity.AccountGenerateEntity;
 import com.se.apiserver.v1.common.domain.entity.BaseEntity;
+import com.se.apiserver.v1.common.domain.exception.BusinessException;
+import com.se.apiserver.v1.lectureroom.application.error.LectureRoomErrorCode;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -36,10 +38,18 @@ public class LectureRoom extends AccountGenerateEntity {
   @Builder
   public LectureRoom(Long lectureRoomId,
       @Size(min = 1, max = 30) String building, Integer roomNumber, Integer capacity) {
+
+    validateCapacity(capacity);
+
     this.lectureRoomId = lectureRoomId;
     this.building = building;
     this.roomNumber = roomNumber;
     this.capacity = capacity;
+  }
+  
+  public void validateCapacity(Integer capacity){
+    if(capacity < 0)
+      throw new BusinessException(LectureRoomErrorCode.INVALID_CAPACITY);
   }
 
   public void updateBuilding(String building){
@@ -51,6 +61,7 @@ public class LectureRoom extends AccountGenerateEntity {
   }
 
   public void updateCapacity(Integer capacity){
+    validateCapacity(capacity);
     this.capacity = capacity;
   }
 }

--- a/src/main/java/com/se/apiserver/v1/opensubject/application/service/OpenSubjectCreateService.java
+++ b/src/main/java/com/se/apiserver/v1/opensubject/application/service/OpenSubjectCreateService.java
@@ -39,18 +39,9 @@ public class OpenSubjectCreateService {
       throw new BusinessException(OpenSubjectErrorCode.DUPLICATED_OPEN_SUBJECT);
     }
 
-    if(request.getTeachingTimePerWeek() != null){
-      if(request.getTeachingTimePerWeek() <= 0)
-        throw new BusinessException(OpenSubjectErrorCode.INVALID_TEACHING_TIME_PER_WEEK);
-    }
-    else{
-      // 주간 강의 시간이 정해져있지 않으면 교과의 학점을 그대로 사용.
+    // 주간 강의 시간이 정해져있지 않으면 교과의 학점을 그대로 사용.
+    if(request.getTeachingTimePerWeek() == null){
       request.setTeachingTimePerWeek(subject.getCredit());
-    }
-
-    if(request.getNumberOfDivision() != null){
-      if(request.getNumberOfDivision() <= 0)
-        throw new BusinessException(OpenSubjectErrorCode.INVALID_NUMBER_OF_DIVISION);
     }
 
     OpenSubject openSubject = OpenSubject.builder()

--- a/src/main/java/com/se/apiserver/v1/opensubject/application/service/OpenSubjectUpdateService.java
+++ b/src/main/java/com/se/apiserver/v1/opensubject/application/service/OpenSubjectUpdateService.java
@@ -25,14 +25,10 @@ public class OpenSubjectUpdateService {
         .orElseThrow(() -> new BusinessException(OpenSubjectErrorCode.NO_SUCH_OPEN_SUBJECT));
 
     if(request.getNumberOfDivision() != null){
-      if(request.getNumberOfDivision() <= 0)
-        throw new BusinessException(OpenSubjectErrorCode.INVALID_NUMBER_OF_DIVISION);
       openSubject.updateNumberOfDivision(request.getNumberOfDivision());
     }
 
     if(request.getTeachingTimePerWeek() != null){
-      if(request.getTeachingTimePerWeek() <= 0)
-        throw new BusinessException(OpenSubjectErrorCode.INVALID_TEACHING_TIME_PER_WEEK);
       openSubject.updateTeachingTimePerWeek(request.getTeachingTimePerWeek());
     }
 

--- a/src/main/java/com/se/apiserver/v1/opensubject/domain/entity/OpenSubject.java
+++ b/src/main/java/com/se/apiserver/v1/opensubject/domain/entity/OpenSubject.java
@@ -1,6 +1,8 @@
 package com.se.apiserver.v1.opensubject.domain.entity;
 
 import com.se.apiserver.v1.common.domain.entity.AccountGenerateEntity;
+import com.se.apiserver.v1.common.domain.exception.BusinessException;
+import com.se.apiserver.v1.opensubject.application.error.OpenSubjectErrorCode;
 import com.se.apiserver.v1.subject.domain.entity.Subject;
 import com.se.apiserver.v1.timetable.domain.entity.TimeTable;
 import javax.persistence.CascadeType;
@@ -43,6 +45,10 @@ public class OpenSubject extends AccountGenerateEntity {
   public OpenSubject(Long openSubjectId,
       TimeTable timeTable, Subject subject, Integer numberOfDivision,
       Integer teachingTimePerWeek) {
+
+    validateNumberOfDivision(numberOfDivision);
+    validateTeachingTimePerWeek(teachingTimePerWeek);
+
     this.openSubjectId = openSubjectId;
     this.timeTable = timeTable;
     this.subject = subject;
@@ -50,11 +56,23 @@ public class OpenSubject extends AccountGenerateEntity {
     this.teachingTimePerWeek = teachingTimePerWeek;
   }
 
+  public void validateNumberOfDivision(Integer numberOfDivision){
+    if(numberOfDivision <= 0)
+      throw new BusinessException(OpenSubjectErrorCode.INVALID_NUMBER_OF_DIVISION);
+  }
+
+  public void validateTeachingTimePerWeek(Integer teachingTimePerWeek){
+    if(teachingTimePerWeek <= 0)
+      throw new BusinessException(OpenSubjectErrorCode.INVALID_TEACHING_TIME_PER_WEEK);
+  }
+
   public void updateNumberOfDivision(Integer numberOfDivision){
+    validateNumberOfDivision(numberOfDivision);
     this.numberOfDivision = numberOfDivision;
   }
 
   public void updateTeachingTimePerWeek(Integer teachingTimePerWeek){
+    validateTeachingTimePerWeek(teachingTimePerWeek);
     this.teachingTimePerWeek = teachingTimePerWeek;
   }
 }

--- a/src/main/java/com/se/apiserver/v1/period/application/error/PeriodErrorCode.java
+++ b/src/main/java/com/se/apiserver/v1/period/application/error/PeriodErrorCode.java
@@ -9,7 +9,8 @@ public enum PeriodErrorCode implements ErrorCode {
   NO_SUCH_PERIOD(400, "PE01", "존재하지 않는 교시"),
   DUPLICATED_PERIOD_ORDER(401, "PE02", "교시 순서 중복"),
   DUPLICATED_PERIOD_NAME(402, "PE03", "교시 이름 중복"),
-  CROSSING_START_END_TIME(403, "PE04", "시작시간과 종료시간이 교차");
+  CROSSING_START_END_TIME(403, "PE04", "시작시간과 종료시간이 교차"),
+  INVALID_PERIOD_ORDER(404, "PE05", "유효하지 않은 교시 순서");
 
   private final int status;
   private final String code;

--- a/src/main/java/com/se/apiserver/v1/period/application/service/PeriodCreateService.java
+++ b/src/main/java/com/se/apiserver/v1/period/application/service/PeriodCreateService.java
@@ -27,11 +27,6 @@ public class PeriodCreateService {
     // 교시 이름이 유니크한지 검사
     checkUniqueName(request.getName());
 
-    // LocalDateTime의 날짜정보를 0년 1월 1일로 바꾸어 시간만 남김.
-
-    // 시작 시간과 종료 시간이 교차하는지 검사
-    checkTimeCrossing(request.getStartTime(), request.getEndTime());
-
     Period period = Period.builder()
         .periodOrder(request.getPeriodOrder())
         .name(request.getName())
@@ -53,10 +48,5 @@ public class PeriodCreateService {
   private void checkUniqueName(String name){
     if(periodJpaRepository.findByName(name).isPresent())
       throw new BusinessException(PeriodErrorCode.DUPLICATED_PERIOD_NAME);
-  }
-
-  private void checkTimeCrossing(LocalTime startTime, LocalTime endTime){
-    if(startTime.isAfter(endTime))
-      throw new BusinessException(PeriodErrorCode.CROSSING_START_END_TIME);
   }
 }

--- a/src/main/java/com/se/apiserver/v1/period/application/service/PeriodUpdateService.java
+++ b/src/main/java/com/se/apiserver/v1/period/application/service/PeriodUpdateService.java
@@ -7,10 +7,8 @@ import com.se.apiserver.v1.period.application.error.PeriodErrorCode;
 import com.se.apiserver.v1.period.application.dto.PeriodReadDto;
 import com.se.apiserver.v1.period.application.dto.PeriodUpdateDto;
 import com.se.apiserver.v1.period.infra.repository.PeriodJpaRepository;
-import java.time.LocalTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,8 +50,7 @@ public class PeriodUpdateService {
       period.updateNote(note);
     }
 
-    // 변경된 시간이 교차되는지 검사
-    checkTimeCrossing(period.getStartTime(), period.getEndTime());
+    period.validateTimeCrossing();
 
     periodJpaRepository.save(period);
     return PeriodReadDto.Response.fromEntity(period);
@@ -73,10 +70,5 @@ public class PeriodUpdateService {
     if(optionalPeriod.isPresent())
       if(!optionalPeriod.get().getPeriodId().equals(request.getPeriodId()))
         throw new BusinessException(PeriodErrorCode.DUPLICATED_PERIOD_NAME);
-  }
-
-  private void checkTimeCrossing(LocalTime startTime, LocalTime endTime){
-    if(startTime.isAfter(endTime))
-      throw new BusinessException(PeriodErrorCode.CROSSING_START_END_TIME);
   }
 }

--- a/src/main/java/com/se/apiserver/v1/period/domain/entity/Period.java
+++ b/src/main/java/com/se/apiserver/v1/period/domain/entity/Period.java
@@ -1,6 +1,8 @@
 package com.se.apiserver.v1.period.domain.entity;
 
 import com.se.apiserver.v1.common.domain.entity.AccountGenerateEntity;
+import com.se.apiserver.v1.common.domain.exception.BusinessException;
+import com.se.apiserver.v1.period.application.error.PeriodErrorCode;
 import java.time.LocalTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -42,15 +44,31 @@ public class Period extends AccountGenerateEntity {
   public Period(Long periodId, Integer periodOrder,
       @Size(min = 1, max = 20) String name, LocalTime startTime, LocalTime endTime,
       @Size(max = 255) String note) {
+
+    validatePeriodOrder(periodOrder);
+
     this.periodId = periodId;
     this.periodOrder = periodOrder;
     this.name = name;
     this.startTime = startTime;
     this.endTime = endTime;
     this.note = note;
+
+    validateTimeCrossing();
+  }
+
+  public void validateTimeCrossing(){
+    if(startTime.isAfter(endTime))
+      throw new BusinessException(PeriodErrorCode.CROSSING_START_END_TIME);
+  }
+
+  public void validatePeriodOrder(Integer periodOrder){
+    if(periodOrder < 0)
+      throw new BusinessException(PeriodErrorCode.INVALID_PERIOD_ORDER);
   }
 
   public void updatePeriodOrder(Integer periodOrder){
+    validatePeriodOrder(periodOrder);
     this.periodOrder = periodOrder;
   }
 

--- a/src/main/java/com/se/apiserver/v1/subject/application/error/SubjectErrorCode.java
+++ b/src/main/java/com/se/apiserver/v1/subject/application/error/SubjectErrorCode.java
@@ -7,7 +7,10 @@ import lombok.Getter;
 public enum SubjectErrorCode implements ErrorCode {
 
   NO_SUCH_SUBJECT(400, "SE01", "존재하지 않는 교과"),
-  DUPLICATED_SUBJECT(401, "SE02", "교과 코드 중복");
+  DUPLICATED_SUBJECT(401, "SE02", "교과 코드 중복"),
+  INVALID_GRADE(402, "SE03", "유효하지 않은 대상학년"),
+  INVALID_SEMESTER(403, "SE04", "유효하지 않은 개설학기"),
+  INVALID_CREDIT(404, "SE05", "유효하지 않은 학점");
 
   private final int status;
   private final String code;

--- a/src/main/java/com/se/apiserver/v1/subject/domain/entity/Subject.java
+++ b/src/main/java/com/se/apiserver/v1/subject/domain/entity/Subject.java
@@ -1,6 +1,8 @@
 package com.se.apiserver.v1.subject.domain.entity;
 
 import com.se.apiserver.v1.common.domain.entity.AccountGenerateEntity;
+import com.se.apiserver.v1.common.domain.exception.BusinessException;
+import com.se.apiserver.v1.subject.application.error.SubjectErrorCode;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -53,6 +55,11 @@ public class Subject extends AccountGenerateEntity {
       @Size(min = 2, max = 30) String curriculum,
       SubjectType type, @Size(min = 2, max = 30) String code,
       @Size(min = 1, max = 50) String name, Integer grade, Integer semester, Integer credit) {
+
+    validateGrade(grade);
+    validateSemester(semester);
+    validateCredit(credit);
+
     this.subjectId = subjectId;
     this.curriculum = curriculum;
     this.type = type;
@@ -61,6 +68,21 @@ public class Subject extends AccountGenerateEntity {
     this.grade = grade;
     this.semester = semester;
     this.credit = credit;
+  }
+
+  public void validateGrade(Integer grade){
+    if(grade < 0)
+      throw new BusinessException(SubjectErrorCode.INVALID_GRADE);
+  }
+
+  public void validateSemester(Integer semester){
+    if(semester < 0)
+      throw new BusinessException(SubjectErrorCode.INVALID_SEMESTER);
+  }
+
+  public void validateCredit(Integer credit){
+    if(credit < 0)
+      throw new BusinessException(SubjectErrorCode.INVALID_CREDIT);
   }
 
   public void updateCurriculum(String curriculum){
@@ -80,14 +102,17 @@ public class Subject extends AccountGenerateEntity {
   }
 
   public void updateGrade(Integer grade){
+    validateGrade(grade);
     this.grade = grade;
   }
 
   public void updateSemester(Integer semester){
+    validateSemester(semester);
     this.semester = semester;
   }
 
   public void updateCredit(Integer credit){
+    validateCredit(credit);
     this.credit = credit;
   }
 }

--- a/src/main/java/com/se/apiserver/v1/timetable/application/error/TimeTableErrorCode.java
+++ b/src/main/java/com/se/apiserver/v1/timetable/application/error/TimeTableErrorCode.java
@@ -7,7 +7,9 @@ import lombok.Getter;
 public enum TimeTableErrorCode implements ErrorCode {
 
   NO_SUCH_TIME_TABLE(400, "TTE01", "존재하지 않는 시간표"),
-  DUPLICATED_TIME_TABLE_NAME(401, "TTE02", "시간표 이름 중복");
+  DUPLICATED_TIME_TABLE_NAME(401, "TTE02", "시간표 이름 중복"),
+  INVALID_YEAR(402, "TTE03", "유효하지 않은 년도"),
+  INVALID_SEMESTER(403, "TTE04", "유효하지 않은 학기");
 
   private final int status;
   private final String code;

--- a/src/main/java/com/se/apiserver/v1/timetable/domain/entity/TimeTable.java
+++ b/src/main/java/com/se/apiserver/v1/timetable/domain/entity/TimeTable.java
@@ -2,6 +2,8 @@ package com.se.apiserver.v1.timetable.domain.entity;
 
 import com.se.apiserver.v1.common.domain.entity.AccountGenerateEntity;
 
+import com.se.apiserver.v1.common.domain.exception.BusinessException;
+import com.se.apiserver.v1.timetable.application.error.TimeTableErrorCode;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -41,6 +43,10 @@ public class TimeTable extends AccountGenerateEntity {
   @Builder
   public TimeTable(Long timeTableId,
       @Size(min = 1, max = 50) String name, Integer year, Integer semester, TimeTableStatus status) {
+
+    validateYear(year);
+    validateSemester(semester);
+
     this.timeTableId = timeTableId;
     this.name = name;
     this.year = year;
@@ -48,15 +54,27 @@ public class TimeTable extends AccountGenerateEntity {
     this.status = status;
   }
 
+  private void validateYear(Integer year){
+    if(year <= 1900)
+      throw new BusinessException(TimeTableErrorCode.INVALID_YEAR);
+  }
+
+  private void validateSemester(Integer semester){
+    if(semester < 0)
+      throw new BusinessException(TimeTableErrorCode.INVALID_SEMESTER);
+  }
+
   public void updateName(String name){
     this.name = name;
   }
 
   public void updateYear(Integer year){
+    validateYear(year);
     this.year = year;
   }
 
   public void updateSemester(Integer semester){
+    validateSemester(semester);
     this.semester = semester;
   }
 

--- a/src/test/java/com/se/apiserver/v1/period/application/service/PeriodCreateServiceTest.java
+++ b/src/test/java/com/se/apiserver/v1/period/application/service/PeriodCreateServiceTest.java
@@ -26,11 +26,10 @@ public class PeriodCreateServiceTest {
   void 교시_생성_성공(){
     // Given
     PeriodCreateDto.Request request = PeriodCreateDto.Request.builder()
-        .periodOrder(1)
-        .name("1")
+        .periodOrder(101)
+        .name("101")
         .startTime(LocalTime.of(9, 0, 0))
         .endTime(LocalTime.of(9, 50, 0))
-        .note("비고 없음")
         .build();
     
     // When
@@ -44,11 +43,10 @@ public class PeriodCreateServiceTest {
   void 교시_생성_시작시간_종료시간_교차_실패(){
     // Given
     PeriodCreateDto.Request request = PeriodCreateDto.Request.builder()
-        .periodOrder(1)
-        .name("1")
+        .periodOrder(101)
+        .name("101")
         .startTime(LocalTime.of(9, 50, 0))
         .endTime(LocalTime.of(9, 0, 0))
-        .note("비고 없음")
         .build();
 
     // When
@@ -62,15 +60,15 @@ public class PeriodCreateServiceTest {
   void 교시_생성_교시_순서_중복_실패(){
     // Given
     periodJpaRepository.save(Period.builder()
-        .periodOrder(1)
-        .name("1")
+        .periodOrder(101)
+        .name("101")
         .startTime(LocalTime.of(9, 0, 0))
         .endTime(LocalTime.of(9, 50, 0))
         .build());
 
     PeriodCreateDto.Request request = PeriodCreateDto.Request.builder()
-        .periodOrder(1)
-        .name("2")
+        .periodOrder(101)
+        .name("102")
         .startTime(LocalTime.of(9, 0, 0))
         .endTime(LocalTime.of(9, 50, 0))
         .build();
@@ -86,15 +84,15 @@ public class PeriodCreateServiceTest {
   void 교시_생성_교시_이름_중복_실패(){
     // Given
     periodJpaRepository.save(Period.builder()
-        .periodOrder(1)
-        .name("1")
+        .periodOrder(101)
+        .name("101")
         .startTime(LocalTime.of(9, 0, 0))
         .endTime(LocalTime.of(9, 50, 0))
         .build());
 
     PeriodCreateDto.Request request = PeriodCreateDto.Request.builder()
-        .periodOrder(2)
-        .name("1")
+        .periodOrder(102)
+        .name("101")
         .startTime(LocalTime.of(10, 0, 0))
         .endTime(LocalTime.of(10, 50, 0))
         .build();

--- a/src/test/java/com/se/apiserver/v1/period/application/service/PeriodDeleteServiceTest.java
+++ b/src/test/java/com/se/apiserver/v1/period/application/service/PeriodDeleteServiceTest.java
@@ -25,8 +25,8 @@ public class PeriodDeleteServiceTest {
   void 교시_삭제_성공(){
     // Given
     Period period = periodJpaRepository.save(Period.builder()
-        .periodOrder(1)
-        .name("1")
+        .periodOrder(101)
+        .name("101")
         .startTime(LocalTime.of(9, 0, 0))
         .endTime(LocalTime.of(9, 50, 0))
         .build());

--- a/src/test/java/com/se/apiserver/v1/period/application/service/PeriodReadServiceTest.java
+++ b/src/test/java/com/se/apiserver/v1/period/application/service/PeriodReadServiceTest.java
@@ -29,8 +29,8 @@ public class PeriodReadServiceTest {
   void 교시_조회_성공(){
     // Given
     Period period = periodJpaRepository.save(Period.builder()
-        .periodOrder(1)
-        .name("1")
+        .periodOrder(101)
+        .name("101")
         .startTime(LocalTime.of(9, 0, 0))
         .endTime(LocalTime.of(9, 50, 0))
         .build());
@@ -58,18 +58,18 @@ public class PeriodReadServiceTest {
   }
 
   @Test
-  void 강의실_전체_조회_성공(){
+  void 교시_전체_조회_성공(){
     // Given
     periodJpaRepository.save(Period.builder()
-        .periodOrder(1)
-        .name("1")
+        .periodOrder(101)
+        .name("101")
         .startTime(LocalTime.of(9, 0, 0))
         .endTime(LocalTime.of(9, 50, 0))
         .build());
 
     periodJpaRepository.save(Period.builder()
-        .periodOrder(2)
-        .name("2")
+        .periodOrder(102)
+        .name("102")
         .startTime(LocalTime.of(10, 0, 0))
         .endTime(LocalTime.of(10, 50, 0))
         .build());
@@ -82,6 +82,6 @@ public class PeriodReadServiceTest {
         .build().of());
 
     // Then
-    Assertions.assertThat(responses.getTotalElements()).isEqualTo(2);
+    Assertions.assertThat(responses.getTotalElements()).isEqualTo(16); // 2개가 되어야 하지만, init_sql로 14개가 생성되므로 16이 맞음.
   }
 }

--- a/src/test/java/com/se/apiserver/v1/period/application/service/PeriodUpdateServiceTest.java
+++ b/src/test/java/com/se/apiserver/v1/period/application/service/PeriodUpdateServiceTest.java
@@ -25,8 +25,8 @@ public class PeriodUpdateServiceTest {
   void 교시_수정_성공(){
     // Given
     Period period = periodJpaRepository.save(Period.builder()
-        .periodOrder(1)
-        .name("1")
+        .periodOrder(101)
+        .name("101")
         .startTime(LocalTime.of(9, 0, 0))
         .endTime(LocalTime.of(9, 50, 0))
         .build());
@@ -36,17 +36,12 @@ public class PeriodUpdateServiceTest {
     // When
     PeriodUpdateDto.Request request = PeriodUpdateDto.Request.builder()
         .periodId(id)
-        .periodOrder(1)
         .name("1A")
-        .startTime(LocalTime.of(10, 0, 0))
-        .endTime(LocalTime.of(10, 50, 0))
         .build();
 
     PeriodReadDto.Response response = periodUpdateService.update(request);
 
     // Then
-    Assertions.assertThat(response.getStartTime()).isEqualTo(LocalTime.of(10, 0, 0));
-    Assertions.assertThat(response.getEndTime()).isEqualTo(LocalTime.of(10, 50, 0));
     Assertions.assertThat(response.getName()).isEqualTo("1A");
   }
 


### PR DESCRIPTION
Service에 있던 검증 중 의존성이 없는 로직을 Entity로 옮기고,
음수 검사와 같은 로직을 새로 추가하였습니다.

변경 사항은 아래와 같습니다.

TimeTable : 년도, 학기 검증
Period : 시작-종료 시간 교차, 교시 순서 검증
LectureRoom : 정원 검증
Subject : 대상학년, 개설학기, 학점 검증
OpenSubject : 분반 수, 주간 수업 시간 검증

+ init_sql로 교시(Period) 정보가 자동 생성됨에 따라 오류가 발생하던 테스트 코드 수정.