### PR TITLE
F/#156 누락된 Transactional 어노테이션 추가

### DIFF
--- a/src/main/java/com/se/apiserver/v1/attach/application/service/AttachCreateService.java
+++ b/src/main/java/com/se/apiserver/v1/attach/application/service/AttachCreateService.java
@@ -25,6 +25,7 @@ public class AttachCreateService {
   private final PostJpaRepository postJpaRepository;
   private final ReplyJpaRepository replyJpaRepository;
 
+  @Transactional
   public AttachReadDto.Response create(AttachCreateDto.Request request){
     validateInvalidInput(request.getPostId(), request.getReplyId());
     Attach attach = getAttach(request);

--- a/src/main/java/com/se/apiserver/v1/attach/application/service/AttachDeleteService.java
+++ b/src/main/java/com/se/apiserver/v1/attach/application/service/AttachDeleteService.java
@@ -15,6 +15,7 @@ public class AttachDeleteService {
 
   private final AttachJpaRepository attachJpaRepository;
 
+  @Transactional
   public boolean delete(Long id) {
     Attach attach = attachJpaRepository.findById(id)
         .orElseThrow(() -> new BusinessException(AttachErrorCode.NO_SUCH_ATTACH));

--- a/src/main/java/com/se/apiserver/v1/authority/application/service/authoritygroupaccountmapping/AuthorityGroupAccountMappingCreateService.java
+++ b/src/main/java/com/se/apiserver/v1/authority/application/service/authoritygroupaccountmapping/AuthorityGroupAccountMappingCreateService.java
@@ -23,6 +23,7 @@ public class AuthorityGroupAccountMappingCreateService {
     private final AccountJpaRepository accountJpaRepository;
     private final AuthorityGroupJpaRepository authorityGroupJpaRepository;
 
+    @Transactional
     public Long create(AuthorityGroupAccountMappingCreateDto.Request request){
         validateAlreadyExistMapping(request.getAccountId(), request.getGroupId());
 

--- a/src/main/java/com/se/apiserver/v1/authority/application/service/authoritygroupaccountmapping/AuthorityGroupAccountMappingDeleteService.java
+++ b/src/main/java/com/se/apiserver/v1/authority/application/service/authoritygroupaccountmapping/AuthorityGroupAccountMappingDeleteService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthorityGroupAccountMappingDeleteService {
     private final AuthorityGroupAccountMappingJpaRepository authorityGroupAccountMappingJpaRepository;
 
+    @Transactional
     public boolean delete(Long id){
         AuthorityGroupAccountMapping authorityGroupAccountMapping = authorityGroupAccountMappingJpaRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(AuthorityGroupAccountMappingErrorCode.NO_SUCH_MAPPING));

--- a/src/main/java/com/se/apiserver/v1/authority/application/service/authoritygroupauthoritymapping/AuthorityGroupAuthorityMappingCreateService.java
+++ b/src/main/java/com/se/apiserver/v1/authority/application/service/authoritygroupauthoritymapping/AuthorityGroupAuthorityMappingCreateService.java
@@ -23,6 +23,7 @@ public class AuthorityGroupAuthorityMappingCreateService {
     private final AuthorityJpaRepository authorityJpaRepository;
     private final AuthorityGroupJpaRepository authorityGroupJpaRepository;
 
+    @Transactional
     public Long create(AuthorityGroupAuthorityMappingCreateDto.Request request){
         validateAlreadyExistMapping(request.getAuthorityId(), request.getGroupId());
         Authority authority = authorityJpaRepository.findById(request.getAuthorityId())

--- a/src/main/java/com/se/apiserver/v1/authority/application/service/authoritygroupauthoritymapping/AuthorityGroupAuthorityMappingDeleteService.java
+++ b/src/main/java/com/se/apiserver/v1/authority/application/service/authoritygroupauthoritymapping/AuthorityGroupAuthorityMappingDeleteService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthorityGroupAuthorityMappingDeleteService {
     private final AuthorityGroupAuthorityMappingJpaRepository authorityGroupAuthorityMappingJpaRepository;
 
+    @Transactional
     public boolean delete(Long id){
         AuthorityGroupAuthorityMapping authorityGroupAuthorityMapping = authorityGroupAuthorityMappingJpaRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(AuthorityGroupAuthorityMappingErrorCode.NO_SUCH_MAPPING));

--- a/src/main/java/com/se/apiserver/v1/blacklist/application/service/BlacklistDeleteService.java
+++ b/src/main/java/com/se/apiserver/v1/blacklist/application/service/BlacklistDeleteService.java
@@ -15,6 +15,7 @@ public class BlacklistDeleteService {
 
     private final BlacklistJpaRepository blacklistJpaRepository;
 
+    @Transactional
     public void delete(Long id) {
         Blacklist blacklist = blacklistJpaRepository.findById(id).orElseThrow(() -> new BusinessException(BlacklistErrorCode.NO_SUCH_BLACKLIST));
         blacklistJpaRepository.delete(blacklist);

--- a/src/main/java/com/se/apiserver/v1/board/application/service/BoardCreateService.java
+++ b/src/main/java/com/se/apiserver/v1/board/application/service/BoardCreateService.java
@@ -20,6 +20,7 @@ public class BoardCreateService {
     private final MenuJpaRepository menuJpaRepository;
     private final AuthorityJpaRepository authorityJpaRepository;
 
+    @Transactional
     public Long create(BoardCreateDto.Request request){
         validateDuplicateNameKor(request.getNameKor());
         validateDuplicateNameEng(request.getNameEng());

--- a/src/main/java/com/se/apiserver/v1/board/application/service/BoardDeleteService.java
+++ b/src/main/java/com/se/apiserver/v1/board/application/service/BoardDeleteService.java
@@ -15,6 +15,7 @@ public class BoardDeleteService {
 
     private final BoardJpaRepository boardJpaRepository;
 
+    @Transactional
     public boolean delete(Long id){
         Board board = boardJpaRepository.findById(id).orElseThrow(() -> new BusinessException(BoardErrorCode.NO_SUCH_BOARD));
         boardJpaRepository.delete(board);

--- a/src/main/java/com/se/apiserver/v1/post/application/service/PostDeleteService.java
+++ b/src/main/java/com/se/apiserver/v1/post/application/service/PostDeleteService.java
@@ -15,6 +15,7 @@ public class PostDeleteService {
 
     private final PostJpaRepository postJpaRepository;
 
+    @Transactional
     public boolean delete(Long postId){
         Post post = postJpaRepository.findById(postId)
                 .orElseThrow(() -> new BusinessException(PostErrorCode.NO_SUCH_POST));

--- a/src/main/java/com/se/apiserver/v1/post/application/service/PostUpdateService.java
+++ b/src/main/java/com/se/apiserver/v1/post/application/service/PostUpdateService.java
@@ -48,7 +48,7 @@ public class PostUpdateService {
             post.validateAccountAccess(contextAccount, authorities);
         }
 
-        if(request.getAnonymousPassword() != null){
+        if(post.getAnonymous() != null && request.getAnonymousPassword() != null){
             validateAnonymousAccess(post.getAnonymous(), request.getAnonymousPassword());
         }
 

--- a/src/main/java/com/se/apiserver/v1/post/infra/repository/PostJpaRepository.java
+++ b/src/main/java/com/se/apiserver/v1/post/infra/repository/PostJpaRepository.java
@@ -9,6 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface PostJpaRepository extends JpaRepository<Post,Long> {
-    @Query("select b from Board b where b = :board")
+    @Query("select p from Post p where p.board = :board")
     Page<Post> findAllByBoard(Board board, Pageable pageable);
 }

--- a/src/main/java/com/se/apiserver/v1/tag/application/service/TagDeleteService.java
+++ b/src/main/java/com/se/apiserver/v1/tag/application/service/TagDeleteService.java
@@ -15,6 +15,7 @@ public class TagDeleteService {
 
     private final TagJpaRepository tagJpaRepository;
 
+    @Transactional
     public boolean delete(Long id) {
         Tag tag = tagJpaRepository.findById(id).orElseThrow(() -> new BusinessException(TagErrorCode.NO_SUCH_TAG));
         tagJpaRepository.delete(tag);

--- a/src/main/java/com/se/apiserver/v1/taglistening/application/service/TagListeningCreateService.java
+++ b/src/main/java/com/se/apiserver/v1/taglistening/application/service/TagListeningCreateService.java
@@ -22,6 +22,7 @@ public class TagListeningCreateService {
     private final TagJpaRepository tagJpaRepository;
     private final AccountContextService accountContextService;
 
+    @Transactional
     public Long create(TagListeningCreateDto.Request request){
         Tag tag = tagJpaRepository.findById(request.getTagId())
                 .orElseThrow(() -> new BusinessException(TagErrorCode.NO_SUCH_TAG));

--- a/src/main/java/com/se/apiserver/v1/taglistening/application/service/TagListeningDeleteService.java
+++ b/src/main/java/com/se/apiserver/v1/taglistening/application/service/TagListeningDeleteService.java
@@ -17,6 +17,7 @@ public class TagListeningDeleteService {
     private final TagListeningJpaRepository tagListeningJpaRepository;
     private final AccountContextService accountContextService;
 
+    @Transactional
     public boolean delete(Long id){
         TagListening tagListening = tagListeningJpaRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(TagListeningErrorCode.NO_SUCH_TAG_TAG_LISTENING));


### PR DESCRIPTION
1. 등록, 수정, 삭제임에도 불구하고 Transactional 어노테이션이 빠진 서비스 메소드에 Transactional 어노테이션 추가.
2. 익명이 아닐 때 익명 비밀번호가 입력된 경우 익명 비밀번호 검사를 수행하지 않게 함.
3. PostJpaRepository에서 게시판으로 조회 시 게시글이 아닌 게시판이 조회되어, 게시글이 조회되도록 수정

#156 
