### PR TITLE
F/#153 파일 삭제 API 구현 및 파일 서버 Error 핸들링 로직 추가

### DIFF
--- a/src/main/java/com/se/apiserver/v1/multipartfile/application/error/FileServerErrorCodeProxy.java
+++ b/src/main/java/com/se/apiserver/v1/multipartfile/application/error/FileServerErrorCodeProxy.java
@@ -1,0 +1,21 @@
+package com.se.apiserver.v1.multipartfile.application.error;
+
+import com.se.apiserver.v1.common.domain.error.ErrorCode;
+import java.beans.ConstructorProperties;
+import lombok.Getter;
+
+// 파일서버로부터 받은 에러 코드
+@Getter
+public class FileServerErrorCodeProxy implements ErrorCode {
+
+  private final String code;
+  private final String message;
+  private int status;
+
+  @ConstructorProperties({"status", "code", "message"})
+  FileServerErrorCodeProxy(final int status, final String code, final String message) {
+    this.status = status;
+    this.message = "FS-" + message;
+    this.code = "FS-" + code;
+  }
+}

--- a/src/main/java/com/se/apiserver/v1/multipartfile/application/error/MultipartFileDeleteErrorCode.java
+++ b/src/main/java/com/se/apiserver/v1/multipartfile/application/error/MultipartFileDeleteErrorCode.java
@@ -1,0 +1,22 @@
+package com.se.apiserver.v1.multipartfile.application.error;
+
+import com.se.apiserver.v1.common.domain.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public enum MultipartFileDeleteErrorCode implements ErrorCode {
+  FAILED_TO_ACCESS_INTERNAL_FILE_SERVER(400, "MFDE01", "파일 서버에 접속할 수 없음"),
+  UNKNOWN_FILE_DELETE_ERROR(400, "MFDE02", "파일 삭제 중 알 수 없는 오류 발생"),
+  FAILED_TO_PARSE_RESPONSE(400, "MFDE03", "파일 서버 응답 파싱 실패");
+
+
+  private final String code;
+  private final String message;
+  private int status;
+
+  MultipartFileDeleteErrorCode(final int status, final String code, final String message) {
+    this.status = status;
+    this.message = message;
+    this.code = code;
+  }
+}

--- a/src/main/java/com/se/apiserver/v1/multipartfile/application/error/MultipartFileDownloadErrorCode.java
+++ b/src/main/java/com/se/apiserver/v1/multipartfile/application/error/MultipartFileDownloadErrorCode.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 
 @Getter
 public enum MultipartFileDownloadErrorCode implements ErrorCode {
-  INTERNAL_FILE_SERVER_ERROR(400, "MFDE01", "내부 파일 서버에서 오류 발생"),
-  UNKNOWN_DOWNLOAD_ERROR(400, "MFDE02", "다운로드 도중 알 수 없는 에러 발생");
+  FAILED_TO_CONNECT_FILE_SERVER(400, "MFDLE01", "파일 서버에 접속할 수 없음"),
+  UNKNOWN_FILE_DOWNLOAD_ERROR(400, "MFDLE02", "파일 다운로드 중 알 수 없는 에러 발생");
 
   private final String code;
   private final String message;

--- a/src/main/java/com/se/apiserver/v1/multipartfile/application/error/MultipartFileUploadErrorCode.java
+++ b/src/main/java/com/se/apiserver/v1/multipartfile/application/error/MultipartFileUploadErrorCode.java
@@ -5,11 +5,11 @@ import lombok.Getter;
 
 @Getter
 public enum MultipartFileUploadErrorCode implements ErrorCode {
-  INVALID_FILE_NAME(400, "MFUE01", "유효하지 않은 파일명"),
-  INVALID_FILE_SIZE(400, "MFUE02", "유효하지 않은 파일 크기"),
-  FILE_SIZE_LIMIT_EXCEEDED(400, "MFUE03", "파일 용량 초과"),
-  UNKNOWN_UPLOAD_ERROR(400, "MFUE04", "업로드 도중 알 수 없는 오류 발생"),
-  INTERNAL_FILE_SERVER_ERROR(400, "MFUE05", "내부 파일 서버에서 오류 발생");
+  FAILED_TO_ACCESS_INTERNAL_FILE_SERVER(400, "MFULE01", "파일 서버에 접속할 수 없음"),
+  UNKNOWN_FILE_UPLOAD_ERROR(400, "MFULE02", "파일 업로드 중 알 수 없는 오류 발생"),
+  INVALID_FILE_SIZE(400, "MFULE03", "유효하지 않은 파일 크기"),
+  FILE_SIZE_LIMIT_EXCEEDED(400, "MFULE04", "파일 용량 초과");
+
 
   private final String code;
   private final String message;

--- a/src/main/java/com/se/apiserver/v1/multipartfile/application/service/MultipartFileDeleteService.java
+++ b/src/main/java/com/se/apiserver/v1/multipartfile/application/service/MultipartFileDeleteService.java
@@ -1,33 +1,35 @@
 package com.se.apiserver.v1.multipartfile.application.service;
 
 import com.se.apiserver.v1.common.domain.exception.BusinessException;
+import com.se.apiserver.v1.multipartfile.application.error.MultipartFileDeleteErrorCode;
 import com.se.apiserver.v1.multipartfile.application.error.MultipartFileDownloadErrorCode;
 import com.se.apiserver.v1.multipartfile.infra.config.MultipartFileProperties;
+
 import java.net.URI;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
 @Service
-public class MultipartFileDownloadService extends MultipartFileService{
+public class MultipartFileDeleteService extends MultipartFileService {
 
-  private final String DOWNLOAD_URL;
+  private final String DELETE_URL;
 
-  public MultipartFileDownloadService(MultipartFileProperties properties){
+  public MultipartFileDeleteService(MultipartFileProperties properties) {
     super(properties);
-    DOWNLOAD_URL = super.BASE_URL + "download/";
+    DELETE_URL = super.BASE_URL + "delete/";
   }
 
-  public ResponseEntity<Resource> download(String saveName){
+  public void delete(final String saveName){
     RestTemplate rest = new RestTemplate();
-    String downloadUrl = DOWNLOAD_URL + saveName;
+
+    String downloadUrl = DELETE_URL + saveName;
 
     try{
-      return rest.exchange(new URI(downloadUrl), HttpMethod.GET, null, Resource.class);
+      rest.exchange(new URI(downloadUrl), HttpMethod.GET, null, Resource.class);
     }
     catch(HttpStatusCodeException e){
       throw super.getBusinessExceptionFromFileServerResponse(e);
@@ -36,7 +38,7 @@ public class MultipartFileDownloadService extends MultipartFileService{
       throw new BusinessException(MultipartFileDownloadErrorCode.FAILED_TO_CONNECT_FILE_SERVER);
     }
     catch (Exception e){
-      throw new BusinessException(MultipartFileDownloadErrorCode.UNKNOWN_FILE_DOWNLOAD_ERROR);
+      throw new BusinessException(MultipartFileDeleteErrorCode.UNKNOWN_FILE_DELETE_ERROR);
     }
   }
 }

--- a/src/main/java/com/se/apiserver/v1/multipartfile/application/service/MultipartFileDeleteService.java
+++ b/src/main/java/com/se/apiserver/v1/multipartfile/application/service/MultipartFileDeleteService.java
@@ -32,7 +32,7 @@ public class MultipartFileDeleteService extends MultipartFileService {
       rest.exchange(new URI(downloadUrl), HttpMethod.GET, null, Resource.class);
     }
     catch(HttpStatusCodeException e){
-      throw super.getBusinessExceptionFromFileServerResponse(e);
+      throw super.getBusinessExceptionFromFileServerException(e);
     }
     catch(ResourceAccessException rae){
       throw new BusinessException(MultipartFileDownloadErrorCode.FAILED_TO_CONNECT_FILE_SERVER);

--- a/src/main/java/com/se/apiserver/v1/multipartfile/application/service/MultipartFileDownloadService.java
+++ b/src/main/java/com/se/apiserver/v1/multipartfile/application/service/MultipartFileDownloadService.java
@@ -30,7 +30,7 @@ public class MultipartFileDownloadService extends MultipartFileService{
       return rest.exchange(new URI(downloadUrl), HttpMethod.GET, null, Resource.class);
     }
     catch(HttpStatusCodeException e){
-      throw super.getBusinessExceptionFromFileServerResponse(e);
+      throw super.getBusinessExceptionFromFileServerException(e);
     }
     catch(ResourceAccessException rae){
       throw new BusinessException(MultipartFileDownloadErrorCode.FAILED_TO_CONNECT_FILE_SERVER);

--- a/src/main/java/com/se/apiserver/v1/multipartfile/application/service/MultipartFileService.java
+++ b/src/main/java/com/se/apiserver/v1/multipartfile/application/service/MultipartFileService.java
@@ -1,0 +1,36 @@
+package com.se.apiserver.v1.multipartfile.application.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.se.apiserver.v1.common.domain.exception.BusinessException;
+import com.se.apiserver.v1.multipartfile.application.error.FileServerErrorCodeProxy;
+import com.se.apiserver.v1.multipartfile.application.error.MultipartFileDeleteErrorCode;
+import com.se.apiserver.v1.multipartfile.infra.config.MultipartFileProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+public abstract class MultipartFileService {
+
+  protected final String BASE_URL;
+
+  @Autowired
+  public MultipartFileService(MultipartFileProperties properties){
+    BASE_URL = "http://" + properties.getFileServerDomain() + "/file/";
+  }
+
+  protected BusinessException getBusinessExceptionFromFileServerResponse(HttpStatusCodeException e){
+    try{
+      String errorCodeJson = e.getResponseBodyAsString();
+      FileServerErrorCodeProxy errorCode = new ObjectMapper().readValue(errorCodeJson, FileServerErrorCodeProxy.class);
+      return new BusinessException(errorCode);
+    }
+    catch (JsonProcessingException jpe){
+      return new BusinessException(MultipartFileDeleteErrorCode.FAILED_TO_PARSE_RESPONSE);
+    }
+  }
+
+  protected String getCurrentHostUrl(){
+    return ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
+  }
+}

--- a/src/main/java/com/se/apiserver/v1/multipartfile/application/service/MultipartFileService.java
+++ b/src/main/java/com/se/apiserver/v1/multipartfile/application/service/MultipartFileService.java
@@ -19,7 +19,7 @@ public abstract class MultipartFileService {
     BASE_URL = "http://" + properties.getFileServerDomain() + "/file/";
   }
 
-  protected BusinessException getBusinessExceptionFromFileServerResponse(HttpStatusCodeException e){
+  protected BusinessException getBusinessExceptionFromFileServerException(HttpStatusCodeException e){
     try{
       String errorCodeJson = e.getResponseBodyAsString();
       FileServerErrorCodeProxy errorCode = new ObjectMapper().readValue(errorCodeJson, FileServerErrorCodeProxy.class);

--- a/src/main/java/com/se/apiserver/v1/multipartfile/application/service/MultipartFileUploadService.java
+++ b/src/main/java/com/se/apiserver/v1/multipartfile/application/service/MultipartFileUploadService.java
@@ -50,7 +50,7 @@ public class MultipartFileUploadService extends MultipartFileService {
       return createExternalDownloadUrl(internalFileDownloadUrl);
     }
     catch(HttpStatusCodeException e){
-      throw super.getBusinessExceptionFromFileServerResponse(e);
+      throw super.getBusinessExceptionFromFileServerException(e);
     }
     catch(ResourceAccessException rae){
       throw new BusinessException(MultipartFileDownloadErrorCode.FAILED_TO_CONNECT_FILE_SERVER);

--- a/src/main/java/com/se/apiserver/v1/multipartfile/infra/api/MultipartFileDeleteController.java
+++ b/src/main/java/com/se/apiserver/v1/multipartfile/infra/api/MultipartFileDeleteController.java
@@ -1,12 +1,11 @@
 package com.se.apiserver.v1.multipartfile.infra.api;
 
+import com.se.apiserver.v1.common.infra.dto.SuccessResponse;
+import com.se.apiserver.v1.multipartfile.application.service.MultipartFileDeleteService;
 import io.swagger.annotations.Api;
-import com.se.apiserver.v1.multipartfile.application.service.MultipartFileDownloadService;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,17 +13,18 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping(value = "multipart-file/download")
-@Api(tags = "파일 다운로드")
-public class MultipartFileDownloadController {
+@RequestMapping(value = "multipart-file/delete")
+@Api(tags = "파일 삭제")
+public class MultipartFileDeleteController {
 
   @Autowired
-  private MultipartFileDownloadService multipartFileDownloadService;
+  private MultipartFileDeleteService multipartFileDeleteService;
 
   @GetMapping("/{saveName:.+}")
-  @ApiOperation("단일 파일 다운로드")
+  @ApiOperation("단일 파일 삭제")
   @ResponseStatus(value = HttpStatus.OK)
-  public ResponseEntity<Resource> downloadFile(@PathVariable String saveName) {
-    return multipartFileDownloadService.download(saveName);
+  public SuccessResponse downloadFile(@PathVariable String saveName) {
+    multipartFileDeleteService.delete(saveName);
+    return new SuccessResponse<>(HttpStatus.OK.value(), "파일 삭제에 성공했습니다.");
   }
 }

--- a/src/main/java/com/se/apiserver/v1/multipartfile/infra/api/MultipartFileUploadController.java
+++ b/src/main/java/com/se/apiserver/v1/multipartfile/infra/api/MultipartFileUploadController.java
@@ -31,7 +31,7 @@ public class MultipartFileUploadController {
   @ResponseStatus(value = HttpStatus.OK)
   public SuccessResponse<String> uploadFile(@RequestParam("file") MultipartFile file){
     // 파일 서버에 전송.
-    return new SuccessResponse<>(HttpStatus.OK.value(), "파일 업로드에 성공했습니다.", multipartFileUploadService.storeFile(file));
+    return new SuccessResponse<>(HttpStatus.OK.value(), "파일 업로드에 성공했습니다.", multipartFileUploadService.upload(file));
   }
 
   @RequestMapping(value = "/multiple/", method = RequestMethod.POST)


### PR DESCRIPTION
파일을 삭제하는 API를 작성하였고
파일 서버에서 예외가 발생했을 때 로직을 추가하였습니다.

파일 서버에서 예외가 발생하면 오류 정보를 담은 ErrorCode를 Json 형태로 API 서버에게 전달합니다.
API 서버는 받은 Json을 Jackson으로 파싱해서 FileServerErrorCodeProxy로 변환 후 BusinessException에 담아 예외를 발생시킵니다.
발생된 예외는 AOP에 전달되어 처리됩니다.

이렇게 하여 API 서버는 파일 서버 내부에서 발생한 문제의 상세정보를 알 수 있습니다.