### PR TITLE
F/#187 게시글 검색 정상적으로 수행되도록 하였음.

### DIFF
--- a/src/main/java/com/se/apiserver/v1/post/application/service/PostDeleteService.java
+++ b/src/main/java/com/se/apiserver/v1/post/application/service/PostDeleteService.java
@@ -29,7 +29,10 @@ public class PostDeleteService {
                     return attach.getSaveName();
                 })
                 .toArray(String[]::new);
-        multipartFileDeleteService.delete(attachSaveNameList);
+
+        if(attachSaveNameList.length > 0)
+            multipartFileDeleteService.delete(attachSaveNameList);
+
         postJpaRepository.delete(post);
         return true;
     }

--- a/src/main/java/com/se/apiserver/v1/post/infra/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/se/apiserver/v1/post/infra/repository/PostQueryRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.se.apiserver.v1.post.infra.repository;
 
 import com.querydsl.jpa.JPQLQuery;
+import com.se.apiserver.v1.account.domain.entity.QAccount;
 import com.se.apiserver.v1.common.domain.exception.BusinessException;
 import com.se.apiserver.v1.post.application.dto.PostReadDto.SearchRequest;
 import com.se.apiserver.v1.post.application.error.PostSearchErrorCode;
@@ -26,6 +27,7 @@ public class PostQueryRepositoryImpl extends QuerydslRepositorySupport implement
       throw new BusinessException(PostSearchErrorCode.INVALID_SEARCH_KEYWORD);
 
     QPost post = QPost.post;
+    QAccount account = QAccount.account;
 
     JPQLQuery query = from(post);
     query.where(post.board.boardId.eq(searchRequest.getBoardId()));
@@ -46,9 +48,11 @@ public class PostQueryRepositoryImpl extends QuerydslRepositorySupport implement
         query.where(post.replies.any().text.contains(keyword));
         break;
       case NICKNAME:
+        query.leftJoin(post.account, account);
         query.where(post.account.nickname.contains(keyword).or(post.anonymous.anonymousNickname.contains(keyword)));
         break;
       case USERID:
+        query.leftJoin(post.account, account);
         query.where(post.anonymous.anonymousNickname.contains(keyword).or(post.account.idString.contains(keyword)));
       case TAG:
         query.where(post.tags.any().tag.text.contains(keyword));

--- a/src/main/java/com/se/apiserver/v1/post/infra/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/se/apiserver/v1/post/infra/repository/PostQueryRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.se.apiserver.v1.common.domain.exception.BusinessException;
 import com.se.apiserver.v1.post.application.dto.PostReadDto.SearchRequest;
 import com.se.apiserver.v1.post.application.error.PostSearchErrorCode;
 import com.se.apiserver.v1.post.domain.entity.Post;
+import com.se.apiserver.v1.post.domain.entity.PostIsSecret;
 import com.se.apiserver.v1.post.domain.entity.QPost;
 import java.util.List;
 import org.springframework.data.domain.Page;
@@ -36,16 +37,17 @@ public class PostQueryRepositoryImpl extends QuerydslRepositorySupport implement
 
     switch (searchRequest.getPostSearchType()){
       case TITLE_TEXT:
-        query.where(post.postContent.title.contains(keyword).or(post.postContent.text.contains(keyword)));
+        query.where(
+            post.postContent.title.contains(keyword).or(post.isSecret.eq(PostIsSecret.NORMAL).and(post.postContent.text.contains(keyword))));
         break;
       case TITLE:
         query.where(post.postContent.title.contains(keyword));
         break;
       case TEXT:
-        query.where(post.postContent.text.contains(keyword));
+        query.where(post.isSecret.eq(PostIsSecret.NORMAL).and(post.postContent.text.contains(keyword)));
         break;
       case REPLY:
-        query.where(post.replies.any().text.contains(keyword));
+        query.where(post.isSecret.eq(PostIsSecret.NORMAL).and(post.replies.any().text.contains(keyword)));
         break;
       case NICKNAME:
         query.leftJoin(post.account, account);

--- a/src/main/java/com/se/apiserver/v1/post/infra/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/se/apiserver/v1/post/infra/repository/PostQueryRepositoryImpl.java
@@ -34,8 +34,7 @@ public class PostQueryRepositoryImpl extends QuerydslRepositorySupport implement
 
     switch (searchRequest.getPostSearchType()){
       case TITLE_TEXT:
-        query.where(post.postContent.title.contains(keyword));
-        query.where(post.postContent.text.contains(keyword));
+        query.where(post.postContent.title.contains(keyword).or(post.postContent.text.contains(keyword)));
         break;
       case TITLE:
         query.where(post.postContent.title.contains(keyword));
@@ -47,12 +46,10 @@ public class PostQueryRepositoryImpl extends QuerydslRepositorySupport implement
         query.where(post.replies.any().text.contains(keyword));
         break;
       case NICKNAME:
-        query.where(post.account.nickname.contains(keyword));
-        query.where(post.anonymous.anonymousNickname.contains(keyword));
+        query.where(post.account.nickname.contains(keyword).or(post.anonymous.anonymousNickname.contains(keyword)));
         break;
       case USERID:
-        query.where(post.anonymous.anonymousNickname.contains(keyword));
-        query.where(post.account.idString.contains(keyword));
+        query.where(post.anonymous.anonymousNickname.contains(keyword).or(post.account.idString.contains(keyword)));
       case TAG:
         query.where(post.tags.any().tag.text.contains(keyword));
         break;


### PR DESCRIPTION
- 제목+내용 검색 시 or 연산으로 수정
- 익명 사용자에 대한 닉네임/ID 검색 시 정상적으로 검색되도록 수정
- 비밀글인 경우 내용에 키워드가 포함되어도 검색결과에 포함되지 않도록 수정
- 게시글 삭제 시 첨부파일이 없는 경우 파일 서버에 요청 보내지 않도록 수정