### PR TITLE
F/#201 Tag가 걸려있는 게시글이 존재할 때 Tag가 삭제되지 않는 오류 픽스

### DIFF
--- a/src/main/java/com/se/apiserver/v1/tag/domain/entity/Tag.java
+++ b/src/main/java/com/se/apiserver/v1/tag/domain/entity/Tag.java
@@ -1,6 +1,9 @@
 package com.se.apiserver.v1.tag.domain.entity;
 
 import com.se.apiserver.v1.common.domain.entity.AccountGenerateEntity;
+import com.se.apiserver.v1.post.domain.entity.PostTagMapping;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,10 +20,12 @@ public class Tag extends AccountGenerateEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long tagId;
 
-
   @Column(columnDefinition = "VARCHAR(30) UNIQUE NOT NULL, FULLTEXT KEY textFulltext (text)")
   @Size(min = 1, max = 30)
   private String text;
+
+  @OneToMany(mappedBy = "tag", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+  private List<PostTagMapping> postTagMapping = new ArrayList<>();
 
   public Tag(@Size(min = 1, max = 30) String text) {
     this.text = text;


### PR DESCRIPTION
Tag에 PostTagMapping과의 양방향 매핑 설정하여,
Tag 삭제 시 PostTagMapping이 Cascading으로 삭제되게 하였음.
