### PR TITLE
F/#209 계정 수정 핫픽스

### DIFF
--- a/src/main/java/com/se/apiserver/v1/account/application/dto/AccountUpdateDto.java
+++ b/src/main/java/com/se/apiserver/v1/account/application/dto/AccountUpdateDto.java
@@ -4,15 +4,19 @@ import com.se.apiserver.v1.account.domain.entity.AccountType;
 import com.se.apiserver.v1.account.domain.entity.InformationOpenAgree;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;
+import lombok.NoArgsConstructor;
 
 public class AccountUpdateDto {
     @Data
     @ApiModel("회원 정보 수정 요청")
+    @AllArgsConstructor
+    @NoArgsConstructor
     @Builder
     static public class Request{
 

--- a/src/main/java/com/se/apiserver/v1/account/application/service/AccountUpdateService.java
+++ b/src/main/java/com/se/apiserver/v1/account/application/service/AccountUpdateService.java
@@ -57,6 +57,8 @@ public class AccountUpdateService {
     }
 
     private void updateQnaIfValid(Account account, Long questionId, String answer) {
+        if(questionId == null && answer == null)
+            return;
         if(questionId == null || answer == null)
             throw new BusinessException(AccountErrorCode.QNA_INVALID_INPUT);
         Question question = questionJpaRepository.findById(questionId).orElseThrow(() -> new BusinessException(AccountErrorCode.NO_SUCH_QUESTION));


### PR DESCRIPTION
- 요청을 모든 변수를 받지 않아도 동작하게 하였음.(dto 수정)
- Q&A 쌍이 모두 비어있는 경우 Q&A 값을 변경하지 않게 하였음.