### PR TITLE
F/#219 게시글 관련 로직 수정

### DIFF
--- a/src/main/java/com/se/apiserver/v1/post/application/error/PostErrorCode.java
+++ b/src/main/java/com/se/apiserver/v1/post/application/error/PostErrorCode.java
@@ -8,10 +8,10 @@ public enum PostErrorCode implements ErrorCode {
     NO_SUCH_POST(400, "PO01", "존재하지 않는 게시글"),
     INVALID_INPUT(400, "PO02", "입력값이 올바르지 않음"),
     ONLY_ADMIN_SET_NOTICE(400, "PO03", "관리자만 공지글 설정 가능합니다"),
-    CAN_NOT_ACCESS_POST(400, "PO04", "해당 게시글에 대한 권한이 없습니다."),
-    ANONYMOUS_PASSWORD_INCORRECT(40, "PO05", "익명 게시글 비밀번호가 틀렸습니다."),
-    NOT_ANONYMOUS_POST(400, "PO06", "익명으로 작성된 게시글이 아닙니다."),
-    DELETED_POST(400, "PO07", "삭제된 게시글입니다.");
+    CAN_NOT_ACCESS_POST(400, "PO04", "해당 게시글에 대한 권한이 없습니다"),
+    ANONYMOUS_PASSWORD_INCORRECT(400, "PO05", "익명 게시글 비밀번호가 틀렸습니다"),
+    NOT_ANONYMOUS_POST(400, "PO06", "익명으로 작성된 게시글이 아닙니다"),
+    DELETED_POST(400, "PO07", "삭제된 게시글입니다");
 
     private int status;
     private final String code;

--- a/src/main/java/com/se/apiserver/v1/post/application/service/PostCreateService.java
+++ b/src/main/java/com/se/apiserver/v1/post/application/service/PostCreateService.java
@@ -7,7 +7,6 @@ import com.se.apiserver.v1.board.domain.entity.Board;
 import com.se.apiserver.v1.board.application.error.BoardErrorCode;
 import com.se.apiserver.v1.board.infra.repository.BoardJpaRepository;
 import com.se.apiserver.v1.common.domain.exception.BusinessException;
-import com.se.apiserver.v1.multipartfile.application.service.MultipartFileUploadService;
 import com.se.apiserver.v1.post.domain.entity.*;
 import com.se.apiserver.v1.attach.application.error.AttachErrorCode;
 import com.se.apiserver.v1.post.application.error.PostErrorCode;
@@ -20,8 +19,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -79,8 +76,10 @@ public class PostCreateService {
 
     // only signed user can add tags
     private List<PostTagMapping> getTagsIfSignIn(List<PostCreateDto.TagDto> tagList) {
-        if(!accountContextService.isSignIn())
+        if(tagList == null || tagList.size() == 0)
             return new ArrayList<>();
+        if(!accountContextService.isSignIn())
+            throw new BusinessException(TagErrorCode.ANONYMOUS_CAN_NOT_TAG);
         return tagList.stream()
                 .map(t -> PostTagMapping.builder()
                         .tag(tagJpaRepository.findById(t.getTagId())
@@ -90,6 +89,8 @@ public class PostCreateService {
     }
 
     private List<Attach> getAttaches(List<PostCreateDto.AttachDto> attachmentList) {
+        if(attachmentList == null || attachmentList.size() == 0)
+            return new ArrayList<>();
         return attachmentList.stream()
                 .map(a -> attachJpaRepository.findById(a.getAttachId())
                         .orElseThrow(() -> new BusinessException(AttachErrorCode.NO_SUCH_ATTACH))

--- a/src/main/java/com/se/apiserver/v1/post/application/service/PostUpdateService.java
+++ b/src/main/java/com/se/apiserver/v1/post/application/service/PostUpdateService.java
@@ -51,7 +51,7 @@ public class PostUpdateService {
         List<PostTagMapping> tags = getTagsIfSignIn(request.getTagList());
         String ip = accountContextService.getCurrentClientIP();
 
-        if(accountContextService.isSignIn()){
+        if(accountContextService.isSignIn() && post.getAnonymous() == null){
             Account contextAccount = accountContextService.getContextAccount();
             post.validateAccountAccess(contextAccount, authorities);
             post.update(board, request.getPostContent(), request.getIsNotice(), request.getIsSecret(), attachList, tags, authorities, ip);

--- a/src/main/java/com/se/apiserver/v1/post/application/service/PostUpdateService.java
+++ b/src/main/java/com/se/apiserver/v1/post/application/service/PostUpdateService.java
@@ -76,8 +76,10 @@ public class PostUpdateService {
 
     // only signed user can add tags
     private List<PostTagMapping> getTagsIfSignIn(List<PostCreateDto.TagDto> tagList) {
-        if(!accountContextService.isSignIn())
+        if(tagList == null || tagList.size() == 0)
             return new ArrayList<>();
+        if(!accountContextService.isSignIn())
+            throw new BusinessException(TagErrorCode.ANONYMOUS_CAN_NOT_TAG);
         return tagList.stream()
                 .map(t -> PostTagMapping.builder()
                         .tag(tagJpaRepository.findById(t.getTagId())
@@ -87,6 +89,8 @@ public class PostUpdateService {
     }
 
     private List<Attach> getAttaches(List<PostCreateDto.AttachDto> attachmentList) {
+        if(attachmentList == null || attachmentList.size() == 0)
+            return new ArrayList<>();
         return attachmentList.stream()
                 .map(a -> attachJpaRepository.findById(a.getAttachId())
                         .orElseThrow(() -> new BusinessException(AttachErrorCode.NO_SUCH_ATTACH))

--- a/src/main/java/com/se/apiserver/v1/post/domain/entity/Post.java
+++ b/src/main/java/com/se/apiserver/v1/post/domain/entity/Post.java
@@ -226,4 +226,8 @@ public class Post extends BaseEntity {
 
     this.postIsDeleted = PostIsDeleted.DELETED;
   }
+
+  public void increaseViews(){
+    views += 1;
+  }
 }

--- a/src/main/java/com/se/apiserver/v1/tag/application/error/TagErrorCode.java
+++ b/src/main/java/com/se/apiserver/v1/tag/application/error/TagErrorCode.java
@@ -6,7 +6,9 @@ import lombok.Getter;
 @Getter
 public enum TagErrorCode implements ErrorCode {
     NO_SUCH_TAG(400,"TG01","존재하지 않는 태그"),
-    DUPLICATED_TAG(401,"TG02","태그명 중복");
+    DUPLICATED_TAG(401,"TG02","태그명 중복"),
+    ANONYMOUS_CAN_NOT_TAG(400, "TG03", "익명 사용자는 태그를 달 수 없습니다");
+
     private int status;
     private final String code;
     private final String message;


### PR DESCRIPTION
- 익명 사용자가 게시글 등록/수정에서 태그를 다는 경우 오류 메시지 반환
- 게시글 등록/수정 시 태그 및 첨부파일이 null이거나 개수가 0 인 경우 예외처리
- 로그인 사용자가 익명 게시글을 수정할 수 있게 하였음(익명 비밀번호가 맞는 경우)
- 게시글 조회 시 게시글 조회수가 올라가도록 하였음