### PR TITLE
F/#263 게시글 조회 시 계정닉네임/익명닉네임으로 오던 전달하던 것을 닉네임으로 통일함

### DIFF
--- a/src/main/java/com/se/apiserver/v1/account/domain/entity/AccountType.java
+++ b/src/main/java/com/se/apiserver/v1/account/domain/entity/AccountType.java
@@ -1,5 +1,5 @@
 package com.se.apiserver.v1.account.domain.entity;
 
 public enum AccountType {
-  STUDENT, PROFESSOR, ASSISTANT, OUTSIDER
+  STUDENT, PROFESSOR, ASSISTANT, OUTSIDER, ANONYMOUS;
 }

--- a/src/main/java/com/se/apiserver/v1/post/application/dto/PostReadDto.java
+++ b/src/main/java/com/se/apiserver/v1/post/application/dto/PostReadDto.java
@@ -2,6 +2,7 @@ package com.se.apiserver.v1.post.application.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.se.apiserver.v1.account.domain.entity.AccountType;
 import com.se.apiserver.v1.attach.domain.entity.Attach;
 import com.se.apiserver.v1.board.domain.entity.Board;
 import com.se.apiserver.v1.common.infra.dto.PageRequest;
@@ -20,7 +21,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 
 public class PostReadDto {
 
@@ -88,6 +88,8 @@ public class PostReadDto {
 
     private String nickname;
 
+    private AccountType accountType;
+
     private LocalDateTime createAt;
 
     @JsonInclude(Include.NON_NULL)
@@ -107,6 +109,8 @@ public class PostReadDto {
           .collect(Collectors.toList())
       );
 
+      AccountType accountType = post.getAccount() == null ? AccountType.ANONYMOUS : post.getAccount().getType();
+
       return builder
               .postId(post.getPostId())
               .boardId(post.getBoard().getBoardId())
@@ -117,6 +121,7 @@ public class PostReadDto {
               .title(post.getPostContent().getTitle())
               .previewText(previewText)
               .nickname(nickname)
+              .accountType(accountType)
               .createAt(post.getCreatedAt())
               .build();
     }
@@ -143,11 +148,9 @@ public class PostReadDto {
 
     private PostIsNotice isNotice;
 
-    @JsonInclude(Include.NON_NULL)
-    private String accountNickname;
+    private String nickname;
 
-    @JsonInclude(Include.NON_NULL)
-    private String anonymousNickname;
+    private AccountType accountType;
 
     @JsonInclude(Include.NON_NULL)
     private PostContent postContent;
@@ -175,12 +178,11 @@ public class PostReadDto {
           .isNotice(post.getIsNotice())
           .createdAt(post.getCreatedAt());
 
-      if (post.getAccount() != null) {
-        builder.accountNickname(post.getAccount().getNickname());
-      }
+      String nickname = post.getAccount() != null ? post.getAccount().getNickname() : post.getAnonymous().getAnonymousNickname();
+      builder.nickname(nickname);
 
-      if(post.getAnonymous() != null)
-        builder.anonymousNickname(post.getAnonymous().getAnonymousNickname());
+      AccountType accountType = post.getAccount() == null ? AccountType.ANONYMOUS : post.getAccount().getType();
+      builder.accountType(accountType);
 
       builder.tags(post.getTags().stream()
           .map(t -> TagDto.fromEntity(t))


### PR DESCRIPTION
- 게시글 목록 조회/조회 시 계정 유형을 함께 반환함.
- 게시글 조회 시 AccounNickname, AnonymousNickname이 아닌, nickname 하나의 파라미터로 반환