### PR TITLE
[KIT-87] API 서버 회원 정보 검색시 Swagger Request 표시 오류 픽스

### DIFF
--- a/src/main/java/com/se/apiserver/v1/account/application/dto/AccountReadDto.java
+++ b/src/main/java/com/se/apiserver/v1/account/application/dto/AccountReadDto.java
@@ -6,9 +6,11 @@ import com.se.apiserver.v1.account.domain.entity.Account;
 import com.se.apiserver.v1.account.domain.entity.AccountType;
 import com.se.apiserver.v1.account.domain.entity.InformationOpenAgree;
 
+import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.NotNull;
 
 import com.se.apiserver.v1.common.infra.dto.PageRequest;
+import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -69,12 +71,24 @@ public class AccountReadDto {
   @NoArgsConstructor
   @AllArgsConstructor
   @Builder
-  static public class SearchRequest{
+  static public class AccountSearchRequest {
+
+    @ApiModelProperty(notes = "검색할 이름", example = "검색할 문자열")
     private String name;
+
+    @ApiModelProperty(notes = "검색할 닉네임", example = "검색할 문자열")
     private String nickname;
+
+    @ApiModelProperty(notes = "검색할 이메일", example = "검색할 문자열")
     private String email;
+
+    @ApiModelProperty(notes = "검색할 학번", example = "검색할 문자열")
     private String studentId;
+
+    @ApiModelProperty(notes = "검색할 휴대폰 번호", example = "검색할 문자열")
     private String phoneNumber;
+
+    @ApiModelProperty(notes = "검색할 계정 유형")
     private AccountType type;
 
     @NotNull

--- a/src/main/java/com/se/apiserver/v1/account/application/service/AccountReadService.java
+++ b/src/main/java/com/se/apiserver/v1/account/application/service/AccountReadService.java
@@ -2,11 +2,9 @@ package com.se.apiserver.v1.account.application.service;
 
 import com.se.apiserver.v1.account.domain.entity.Account;
 import com.se.apiserver.v1.account.application.error.AccountErrorCode;
-import com.se.apiserver.v1.account.application.dto.AccountReadDto;
 import com.se.apiserver.v1.common.domain.exception.BusinessException;
 import com.se.apiserver.v1.account.infra.repository.AccountJpaRepository;
 import com.se.apiserver.v1.account.infra.repository.AccountQueryRepository;
-import com.se.apiserver.v1.menu.application.dto.MenuReadDto.ReadResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 
@@ -55,7 +53,7 @@ public class AccountReadService {
 
 
 
-    public PageImpl search(AccountReadDto.SearchRequest pageRequest) {
+    public PageImpl search(AccountSearchRequest pageRequest) {
         Page<Account> accountPage = accountQueryRepository.search(pageRequest);
         List<Response> res = accountPage.get().map(account -> Response.fromEntity(account, isLegalAccess(account)))
                 .collect(Collectors.toList());

--- a/src/main/java/com/se/apiserver/v1/account/infra/api/AccountApiController.java
+++ b/src/main/java/com/se/apiserver/v1/account/infra/api/AccountApiController.java
@@ -1,5 +1,6 @@
 package com.se.apiserver.v1.account.infra.api;
 
+import com.se.apiserver.v1.account.application.dto.AccountReadDto.AccountSearchRequest;
 import com.se.apiserver.v1.account.application.dto.QuestionReadDto.Response;
 import com.se.apiserver.v1.common.infra.dto.PageRequest;
 import com.se.apiserver.v1.common.infra.dto.SuccessResponse;
@@ -154,8 +155,9 @@ public class AccountApiController {
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("hasAnyAuthority('ACCOUNT_MANAGE')")
     @ApiOperation(value = "회원 정보 검색")
-    public SuccessResponse<Pageable> searchAccount(@RequestBody @Validated AccountReadDto.SearchRequest searchRequest) {
-        return new SuccessResponse(HttpStatus.OK.value(), "조회 성공", accountReadService.search(searchRequest));
+    public SuccessResponse<Pageable> searchAccount(@RequestBody @Validated AccountSearchRequest accountSearchRequest) {
+        return new SuccessResponse(HttpStatus.OK.value(), "조회 성공", accountReadService.search(
+            accountSearchRequest));
     }
 
     @GetMapping(path = "/account/question")

--- a/src/main/java/com/se/apiserver/v1/account/infra/repository/AccountQueryRepository.java
+++ b/src/main/java/com/se/apiserver/v1/account/infra/repository/AccountQueryRepository.java
@@ -1,10 +1,10 @@
 package com.se.apiserver.v1.account.infra.repository;
 
+import com.se.apiserver.v1.account.application.dto.AccountReadDto.AccountSearchRequest;
 import com.se.apiserver.v1.account.domain.entity.Account;
-import com.se.apiserver.v1.account.application.dto.AccountReadDto;
 import org.springframework.data.domain.Page;
 
 public interface AccountQueryRepository {
-    Page<Account> search(AccountReadDto.SearchRequest searchRequest);
+    Page<Account> search(AccountSearchRequest accountSearchRequest);
 
 }

--- a/src/main/java/com/se/apiserver/v1/account/infra/repository/AccountQueryRepositoryImpl.java
+++ b/src/main/java/com/se/apiserver/v1/account/infra/repository/AccountQueryRepositoryImpl.java
@@ -1,9 +1,9 @@
 package com.se.apiserver.v1.account.infra.repository;
 
 import com.querydsl.jpa.JPQLQuery;
+import com.se.apiserver.v1.account.application.dto.AccountReadDto.AccountSearchRequest;
 import com.se.apiserver.v1.account.domain.entity.Account;
 import com.se.apiserver.v1.account.domain.entity.QAccount;
-import com.se.apiserver.v1.account.application.dto.AccountReadDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -19,29 +19,29 @@ public class AccountQueryRepositoryImpl extends QuerydslRepositorySupport implem
     }
 
     @Override
-    public Page<Account> search(AccountReadDto.SearchRequest searchRequest) {
+    public Page<Account> search(AccountSearchRequest accountSearchRequest) {
         QAccount account = QAccount.account;
 
         JPQLQuery query = from(account);
-        if(searchRequest.getName() != null){
-            query.where(account.name.contains(searchRequest.getName()));
+        if(accountSearchRequest.getName() != null){
+            query.where(account.name.contains(accountSearchRequest.getName()));
         }
-        if(searchRequest.getNickname() != null){
-            query.where(account.nickname.contains(searchRequest.getNickname()));
+        if(accountSearchRequest.getNickname() != null){
+            query.where(account.nickname.contains(accountSearchRequest.getNickname()));
         }
-        if(searchRequest.getEmail() != null){
-            query.where(account.email.contains(searchRequest.getEmail()));
+        if(accountSearchRequest.getEmail() != null){
+            query.where(account.email.contains(accountSearchRequest.getEmail()));
         }
-        if(searchRequest.getStudentId() != null){
-            query.where(account.studentId.contains(searchRequest.getStudentId()));
+        if(accountSearchRequest.getStudentId() != null){
+            query.where(account.studentId.contains(accountSearchRequest.getStudentId()));
         }
-        if(searchRequest.getPhoneNumber() != null){
-            query.where(account.phoneNumber.contains(searchRequest.getPhoneNumber()));
+        if(accountSearchRequest.getPhoneNumber() != null){
+            query.where(account.phoneNumber.contains(accountSearchRequest.getPhoneNumber()));
         }
-        if(searchRequest.getType() != null){
-            query.where(account.type.eq(searchRequest.getType()));
+        if(accountSearchRequest.getType() != null){
+            query.where(account.type.eq(accountSearchRequest.getType()));
         }
-        Pageable pageable = searchRequest.getPageRequest().of();
+        Pageable pageable = accountSearchRequest.getPageRequest().of();
         List<Account> accounts = getQuerydsl().applyPagination(pageable, query).fetch();
         long totalCount = query.fetchCount();
         return new PageImpl(accounts, pageable, totalCount);

--- a/src/main/java/com/se/apiserver/v1/post/application/dto/PostReadDto.java
+++ b/src/main/java/com/se/apiserver/v1/post/application/dto/PostReadDto.java
@@ -30,7 +30,7 @@ public class PostReadDto {
   @NoArgsConstructor
   @AllArgsConstructor
   @Builder
-  static public class SearchRequest{
+  static public class PostSearchRequest {
 
     @ApiModelProperty(notes = "게시판 아이디", example = "1")
     private Long boardId;

--- a/src/main/java/com/se/apiserver/v1/post/application/service/PostReadService.java
+++ b/src/main/java/com/se/apiserver/v1/post/application/service/PostReadService.java
@@ -6,6 +6,7 @@ import com.se.apiserver.v1.board.application.error.BoardErrorCode;
 import com.se.apiserver.v1.board.infra.repository.BoardJpaRepository;
 import com.se.apiserver.v1.common.domain.exception.BusinessException;
 import com.se.apiserver.v1.post.application.dto.PostAccessCheckDto;
+import com.se.apiserver.v1.post.application.dto.PostReadDto.PostSearchRequest;
 import com.se.apiserver.v1.post.domain.entity.Post;
 import com.se.apiserver.v1.post.application.error.PostErrorCode;
 import com.se.apiserver.v1.post.domain.entity.PostIsSecret;
@@ -83,7 +84,7 @@ public class PostReadService {
         return PostReadDto.PostListResponse.fromEntity(new PageImpl<>(list, allByBoard.getPageable(), allByBoard.getTotalElements()), board);
     }
 
-    public PostReadDto.PostListResponse search(PostReadDto.SearchRequest pageRequest){
+    public PostReadDto.PostListResponse search(PostSearchRequest pageRequest){
         Board board = boardJpaRepository.findById(pageRequest.getBoardId())
                 .orElseThrow(() -> new BusinessException(BoardErrorCode.NO_SUCH_BOARD));
         Set<String> authorities = accountContextService.getContextAuthorities();

--- a/src/main/java/com/se/apiserver/v1/post/infra/api/PostApiController.java
+++ b/src/main/java/com/se/apiserver/v1/post/infra/api/PostApiController.java
@@ -3,6 +3,7 @@ package com.se.apiserver.v1.post.infra.api;
 import com.se.apiserver.v1.common.infra.dto.PageRequest;
 import com.se.apiserver.v1.common.infra.dto.SuccessResponse;
 import com.se.apiserver.v1.post.application.dto.*;
+import com.se.apiserver.v1.post.application.dto.PostReadDto.PostSearchRequest;
 import com.se.apiserver.v1.post.application.service.PostCreateService;
 import com.se.apiserver.v1.post.application.service.PostDeleteService;
 import com.se.apiserver.v1.post.application.service.PostReadService;
@@ -83,8 +84,9 @@ public class PostApiController {
     @PostMapping("/post/search")
     @ResponseStatus(value = HttpStatus.OK)
     @ApiOperation(value = "게시글 검색")
-    public SuccessResponse<Pageable> searchPost(@RequestBody @Validated PostReadDto.SearchRequest searchRequest) {
-        return new SuccessResponse(HttpStatus.OK.value(), "조회 성공", postReadService.search(searchRequest));
+    public SuccessResponse<Pageable> searchPost(@RequestBody @Validated PostSearchRequest postSearchRequest) {
+        return new SuccessResponse(HttpStatus.OK.value(), "조회 성공", postReadService.search(
+            postSearchRequest));
     }
 
     @PostMapping("/post/anonymous")

--- a/src/main/java/com/se/apiserver/v1/post/infra/repository/PostQueryRepository.java
+++ b/src/main/java/com/se/apiserver/v1/post/infra/repository/PostQueryRepository.java
@@ -1,9 +1,9 @@
 package com.se.apiserver.v1.post.infra.repository;
 
-import com.se.apiserver.v1.post.application.dto.PostReadDto;
+import com.se.apiserver.v1.post.application.dto.PostReadDto.PostSearchRequest;
 import com.se.apiserver.v1.post.domain.entity.Post;
 import org.springframework.data.domain.Page;
 
 public interface PostQueryRepository {
-  Page<Post> search(PostReadDto.SearchRequest searchRequest);
+  Page<Post> search(PostSearchRequest postSearchRequest);
 }

--- a/src/main/java/com/se/apiserver/v1/post/infra/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/se/apiserver/v1/post/infra/repository/PostQueryRepositoryImpl.java
@@ -3,7 +3,7 @@ package com.se.apiserver.v1.post.infra.repository;
 import com.querydsl.jpa.JPQLQuery;
 import com.se.apiserver.v1.account.domain.entity.QAccount;
 import com.se.apiserver.v1.common.domain.exception.BusinessException;
-import com.se.apiserver.v1.post.application.dto.PostReadDto.SearchRequest;
+import com.se.apiserver.v1.post.application.dto.PostReadDto.PostSearchRequest;
 import com.se.apiserver.v1.post.application.error.PostSearchErrorCode;
 import com.se.apiserver.v1.post.domain.entity.Post;
 import com.se.apiserver.v1.post.domain.entity.PostIsSecret;
@@ -23,19 +23,19 @@ public class PostQueryRepositoryImpl extends QuerydslRepositorySupport implement
   }
 
   @Override
-  public Page<Post> search(SearchRequest searchRequest) {
-    if(searchRequest.getKeyword() == null || searchRequest.getKeyword().length() < 1)
+  public Page<Post> search(PostSearchRequest postSearchRequest) {
+    if(postSearchRequest.getKeyword() == null || postSearchRequest.getKeyword().length() < 1)
       throw new BusinessException(PostSearchErrorCode.INVALID_SEARCH_KEYWORD);
 
     QPost post = QPost.post;
     QAccount account = QAccount.account;
 
     JPQLQuery query = from(post);
-    query.where(post.board.boardId.eq(searchRequest.getBoardId()));
+    query.where(post.board.boardId.eq(postSearchRequest.getBoardId()));
 
-    String keyword = searchRequest.getKeyword();
+    String keyword = postSearchRequest.getKeyword();
 
-    switch (searchRequest.getPostSearchType()){
+    switch (postSearchRequest.getPostSearchType()){
       case TITLE_TEXT:
         query.where(
             post.postContent.title.contains(keyword).or(post.isSecret.eq(PostIsSecret.NORMAL).and(post.postContent.text.contains(keyword))));
@@ -65,7 +65,7 @@ public class PostQueryRepositoryImpl extends QuerydslRepositorySupport implement
     }
 
 
-    Pageable pageable = searchRequest.getPageRequest().of();
+    Pageable pageable = postSearchRequest.getPageRequest().of();
     List<Post> posts = getQuerydsl().applyPagination(pageable, query).fetch();
     long totalCount = query.fetchCount();
     return new PageImpl<>(posts, pageable, totalCount);

--- a/src/test/java/com/se/apiserver/v1/account/application/service/AccountReadServiceTest.java
+++ b/src/test/java/com/se/apiserver/v1/account/application/service/AccountReadServiceTest.java
@@ -1,5 +1,6 @@
 package com.se.apiserver.v1.account.application.service;
 
+import com.se.apiserver.v1.account.application.dto.AccountReadDto.AccountSearchRequest;
 import com.se.apiserver.v1.account.domain.entity.Account;
 import com.se.apiserver.v1.account.domain.entity.AccountType;
 import com.se.apiserver.v1.account.domain.entity.InformationOpenAgree;
@@ -123,7 +124,7 @@ public class AccountReadServiceTest {
         SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken("1",
             "1", Arrays.asList(new SimpleGrantedAuthority("ACCOUNT_ACCESS"))));
         //when
-        PageImpl search = accountReadService.search(AccountReadDto.SearchRequest.builder()
+        PageImpl search = accountReadService.search(AccountSearchRequest.builder()
                 .pageRequest(PageRequest.builder().page(1).size(10).direction(Sort.Direction.ASC).build())
                 .build());
         //then


### PR DESCRIPTION
# Pull Request Check List
- Major Reviewer: @KitTeamSe/be 

## CheckList

- [ ] Unit test coverage
- [ ] Backward compatibility
- [ ] Tested on dev/staging environment
- [ ] Documentation
- [x] Self reviewed

## Context

게시물 검색 DTO의 이름이 SearchRequest고, 회원 정보 검색 DTO의 이름이 SearchRequest로 동일해서
스웨거에서 회원 정보 검색 DTO를 잡지 못하고 게시물 검색 DTO로 잡았던 것으로 보입니다.
두 클래스의 이름을 PostSearchDTO, AccountSearchDTO로 수정하였습니다.