### PR TITLE
[KIT-93] 만료된 토큰으로 요청 시 CORS 에러가 발생하는 버그 픽스

### DIFF
--- a/src/main/java/com/se/apiserver/v1/common/infra/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/se/apiserver/v1/common/infra/security/config/WebSecurityConfig.java
@@ -8,6 +8,7 @@ import com.se.apiserver.v1.blacklist.application.service.BlacklistDetailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -45,6 +46,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers("/api/v1/signup", "/api/v1/signin").permitAll()
                 .antMatchers("/swagger-resources/**", "/swagger-ui.html", "/webjars/**").permitAll()
+                .antMatchers(HttpMethod.OPTIONS, "/api/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilters(jwtTokenResolver), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/se/apiserver/v1/common/infra/security/filter/FilterChainExceptionHandler.java
+++ b/src/main/java/com/se/apiserver/v1/common/infra/security/filter/FilterChainExceptionHandler.java
@@ -22,14 +22,27 @@ public class FilterChainExceptionHandler extends OncePerRequestFilter {
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain){
     try {
       filterChain.doFilter(request, response);
-    } catch (BusinessException e) {
-      resolver.resolveException(request, response, null, e);
     }
     catch (Exception e){
-      // 비지니스 익셉션이 아닌 경우
-      logger.error(e);
-      e.printStackTrace();
-      resolver.resolveException(request, response, null, new BusinessException(GlobalErrorCode.UNKNOWN_NON_BUSINESS_ERROR));
+      if(e instanceof BusinessException){
+        resolveException(request, response, (BusinessException) e);
+      }
+      else{
+        logger.error(e);
+        e.printStackTrace();
+        resolveException(request, response, new BusinessException(GlobalErrorCode.UNKNOWN_NON_BUSINESS_ERROR));
+      }
     }
+  }
+
+  private void resolveException(HttpServletRequest request, HttpServletResponse response, BusinessException e){
+    setHeaderForCors(response);
+    resolver.resolveException(request, response, null, e);
+  }
+
+  private void setHeaderForCors(HttpServletResponse response){
+    response.setHeader("Access-Control-Allow-Origin", "*");
+    response.setHeader("Access-Control-Allow-Methods", "POST, GET, DELETE, PUT");
+    response.setHeader("Access-Control-Allow-Headers", "Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With,observe");
   }
 }

--- a/src/main/java/com/se/apiserver/v1/common/infra/security/filter/FilterChainExceptionHandler.java
+++ b/src/main/java/com/se/apiserver/v1/common/infra/security/filter/FilterChainExceptionHandler.java
@@ -23,15 +23,13 @@ public class FilterChainExceptionHandler extends OncePerRequestFilter {
     try {
       filterChain.doFilter(request, response);
     }
+    catch (BusinessException e){
+      resolveException(request, response, e);
+    }
     catch (Exception e){
-      if(e instanceof BusinessException){
-        resolveException(request, response, (BusinessException) e);
-      }
-      else{
-        logger.error(e);
-        e.printStackTrace();
-        resolveException(request, response, new BusinessException(GlobalErrorCode.UNKNOWN_NON_BUSINESS_ERROR));
-      }
+      logger.error(e);
+      e.printStackTrace();
+      resolveException(request, response, new BusinessException(GlobalErrorCode.UNKNOWN_NON_BUSINESS_ERROR));
     }
   }
 


### PR DESCRIPTION
# Pull Request Check List
- Major Reviewer: @junhodo 

## CheckList

- [ ] Unit test coverage
- [ ] Backward compatibility
- [ ] Tested on dev/staging environment
- [ ] Documentation
- [x] Self reviewed

## Context

- 유효한 토큰을 가지고 있는 경우, Filter를 거치면서 응답 헤더에 CORS 설정을 넣은 후 예외가 발생해서 문제가 없습니다.
- 유효하지 않은 토큰을 가진 경우, FIlter를 거치던 도중 예외가 발생해서(아마도 토큰 검증 필터에서) 응답 헤더에 CORS 설정이 들어가지 않은 것으로 보입니다.
- 그래서 Filter에서 예외가 발생한 경우 응답 헤더에 CORS 관련 설정을 하게 하였습니다.

## 추가 Context : Preflight
- 요청 헤더에 X-AUTH-TOKEN이 포함된 경우 일반적인 요청이지 않다고 판단합니다.
때문에 HTTP METHOD를 OPTIONS로, 빈 body로 요청을 미리 한번 해본 후 요청을 보냅니다.
- 테스트 도중 preflight 관련 에러 또한 발생해서
이를 허용해주도록 WebSecurityConfig.java에 허용 구문을 추가했습니다.

참고 : https://ahndding.tistory.com/17
