### PR TITLE
[KIT-90] 태그 검색 시 영문 대소문자를 구분하지 않게 수정

### DIFF
--- a/src/main/java/com/se/apiserver/v1/tag/application/service/TagReadService.java
+++ b/src/main/java/com/se/apiserver/v1/tag/application/service/TagReadService.java
@@ -34,7 +34,7 @@ public class TagReadService {
         if(!accountContextService.isSignIn())
             throw new BusinessException(GlobalErrorCode.HANDLE_ACCESS_DENIED);
 
-        List<Tag> tags = tagJpaRepository.findByTextContaining(text);
+        List<Tag> tags = tagJpaRepository.findByTextContainingIgnoreCase(text);
         return tags.stream().map(a -> TagReadDto.Response.fromEntity(a)).collect(Collectors.toList());
     }
 

--- a/src/main/java/com/se/apiserver/v1/tag/infra/repository/TagJpaRepository.java
+++ b/src/main/java/com/se/apiserver/v1/tag/infra/repository/TagJpaRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 public interface TagJpaRepository extends JpaRepository<Tag,Long> {
     Optional<Tag> findByText(String text);
-    List<Tag> findByTextContaining(String text);
+    List<Tag> findByTextContainingIgnoreCase(String text);
 }


### PR DESCRIPTION
# Pull Request Check List
- Major Reviewer: @KitTeamSe/be 

## CheckList

- [ ] Unit test coverage
- [ ] Backward compatibility
- [ ] Tested on dev/staging environment
- [ ] Documentation
- [x] Self reviewed

## Context

기존 함수에 IgnoreCase를 추가하여 대소문자를 구분하지 않도록 수정하였습니다.
해당 함수명을 수정하였을때, 아래의 형식으로 수정됩니다.
```
select * from tag 
where upper(text) like upper(?)
```