### PR TITLE
[KIT-120] 댓글 테스트 작성 및 트러블 슈팅 / 댓글 생성 로직 수정

### DIFF
--- a/src/main/java/com/se/apiserver/v1/attach/application/dto/AttachReadDto.java
+++ b/src/main/java/com/se/apiserver/v1/attach/application/dto/AttachReadDto.java
@@ -6,9 +6,19 @@ import com.se.apiserver.v1.attach.domain.entity.Attach;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class AttachReadDto {
+
+  @Getter
+  static public class Request {
+    public Request(Long attachId) {
+      this.attachId = attachId;
+    }
+
+    private Long attachId;
+  }
 
   @Data
   @NoArgsConstructor

--- a/src/main/java/com/se/apiserver/v1/attach/application/service/AttachCreateService.java
+++ b/src/main/java/com/se/apiserver/v1/attach/application/service/AttachCreateService.java
@@ -5,6 +5,7 @@ import com.se.apiserver.v1.attach.domain.entity.Attach;
 import com.se.apiserver.v1.attach.application.error.AttachErrorCode;
 import com.se.apiserver.v1.attach.application.dto.AttachReadDto;
 import com.se.apiserver.v1.attach.application.dto.AttachReadDto.Response;
+import com.se.apiserver.v1.attach.domain.entity.AttachCreateFuncType;
 import com.se.apiserver.v1.common.domain.exception.BusinessException;
 import com.se.apiserver.v1.multipartfile.application.dto.MultipartFileUploadDto;
 import com.se.apiserver.v1.multipartfile.application.service.MultipartFileUploadService;
@@ -25,10 +26,6 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 @Transactional(readOnly = true)
 public class AttachCreateService {
-
-  private static final int CREATE_FILES = 1;
-  private static final int SET_FILES_OWNER = 2;
-
   private final MultipartFileUploadService multipartFileUploadService;
   private final AttachJpaRepository attachJpaRepository;
   private final PostJpaRepository postJpaRepository;
@@ -47,7 +44,7 @@ public class AttachCreateService {
 
   @Transactional
   public AttachReadDto.Response create(Long postId, Long replyId, MultipartFile multipartFile) {
-    validateInvalidInput(postId, replyId, CREATE_FILES);
+    validateInvalidInput(postId, replyId, AttachCreateFuncType.CREATE_FILES);
     Attach attach = getAttach(postId, replyId, multipartFile);
     Attach save = attachJpaRepository.save(attach);
     return Response.fromEntity(save);
@@ -56,7 +53,7 @@ public class AttachCreateService {
   @Transactional
   public List<AttachReadDto.Response> createFiles(Long postId, Long replyId,
       MultipartFile[] multipartFiles) {
-    validateInvalidInput(postId, replyId, CREATE_FILES);
+    validateInvalidInput(postId, replyId, AttachCreateFuncType.CREATE_FILES);
 
     List<Attach> attachList = new ArrayList<>();
     for (MultipartFile file : multipartFiles) {
@@ -70,8 +67,8 @@ public class AttachCreateService {
         .collect(Collectors.toList());
   }
 
-  public void setFileOwner(Long postId, Long replyId, List<AttachReadDto.Request> requestList) {
-    validateInvalidInput(postId, replyId, SET_FILES_OWNER);
+  public void setFilesOwner(Long postId, Long replyId, List<AttachReadDto.Request> requestList) {
+    validateInvalidInput(postId, replyId, AttachCreateFuncType.SET_FILES_OWNER);
 
     List<Long> attachIdVals = requestList
         .stream()
@@ -96,7 +93,7 @@ public class AttachCreateService {
     attachJpaRepository.saveAll(attachList);
   }
 
-  private void validateInvalidInput(Long postId, Long replyId, int type) {
+  private void validateInvalidInput(Long postId, Long replyId, AttachCreateFuncType type) {
     switch(type) {
       case CREATE_FILES:
         if (postId != null && replyId != null) {

--- a/src/main/java/com/se/apiserver/v1/attach/application/service/AttachCreateService.java
+++ b/src/main/java/com/se/apiserver/v1/attach/application/service/AttachCreateService.java
@@ -1,5 +1,6 @@
 package com.se.apiserver.v1.attach.application.service;
 
+import com.se.apiserver.v1.attach.application.dto.AttachReadDto.Request;
 import com.se.apiserver.v1.attach.domain.entity.Attach;
 import com.se.apiserver.v1.attach.application.error.AttachErrorCode;
 import com.se.apiserver.v1.attach.application.dto.AttachReadDto;
@@ -14,55 +15,122 @@ import com.se.apiserver.v1.post.infra.repository.PostJpaRepository;
 import com.se.apiserver.v1.reply.domain.entity.Reply;
 import com.se.apiserver.v1.reply.application.error.ReplyErrorCode;
 import com.se.apiserver.v1.reply.infra.repository.ReplyJpaRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
-@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AttachCreateService {
 
-  @Autowired
-  private final MultipartFileUploadService multipartFileUploadService;
+  private static final int CREATE_FILES = 1;
+  private static final int SET_FILES_OWNER = 2;
 
+  private final MultipartFileUploadService multipartFileUploadService;
   private final AttachJpaRepository attachJpaRepository;
   private final PostJpaRepository postJpaRepository;
   private final ReplyJpaRepository replyJpaRepository;
 
+  public AttachCreateService(
+      MultipartFileUploadService multipartFileUploadService,
+      AttachJpaRepository attachJpaRepository,
+      PostJpaRepository postJpaRepository,
+      ReplyJpaRepository replyJpaRepository) {
+    this.multipartFileUploadService = multipartFileUploadService;
+    this.attachJpaRepository = attachJpaRepository;
+    this.postJpaRepository = postJpaRepository;
+    this.replyJpaRepository = replyJpaRepository;
+  }
+
   @Transactional
-  public AttachReadDto.Response create(Long postId, Long replyId, MultipartFile multipartFile){
-    validateInvalidInput(postId, replyId);
+  public AttachReadDto.Response create(Long postId, Long replyId, MultipartFile multipartFile) {
+    validateInvalidInput(postId, replyId, CREATE_FILES);
     Attach attach = getAttach(postId, replyId, multipartFile);
     Attach save = attachJpaRepository.save(attach);
     return Response.fromEntity(save);
   }
 
-  private void validateInvalidInput(Long postId, Long replyId) {
-    if(postId != null && replyId != null)
-      throw new BusinessException(AttachErrorCode.INVALID_INPUT);
+  @Transactional
+  public List<AttachReadDto.Response> createFiles(Long postId, Long replyId,
+      MultipartFile[] multipartFiles) {
+    validateInvalidInput(postId, replyId, CREATE_FILES);
+
+    List<Attach> attachList = new ArrayList<>();
+    for (MultipartFile file : multipartFiles) {
+      attachList.add(getAttach(postId, replyId, file));
+    }
+
+    return attachJpaRepository.saveAll(attachList)
+        .stream()
+        .map(attach -> new Response(attach.getAttachId(), postId, replyId,
+            attach.getDownloadUrl(), attach.getFileName()))
+        .collect(Collectors.toList());
+  }
+
+  public void setFileOwner(Long postId, Long replyId, List<AttachReadDto.Request> requestList) {
+    validateInvalidInput(postId, replyId, SET_FILES_OWNER);
+
+    List<Long> attachIdVals = requestList
+        .stream()
+        .map(Request::getAttachId)
+        .collect(Collectors.toList());
+    List<Attach> attachList = attachJpaRepository.findAllByAttachId(attachIdVals);
+
+    if (postId != null) {
+      Post post = postJpaRepository.findById(postId)
+          .orElseThrow(() -> new BusinessException(PostErrorCode.NO_SUCH_POST));
+      for (Attach attach : attachList) {
+        attach.setPost(post);
+      }
+    } else {
+      Reply reply = replyJpaRepository.findById(replyId)
+          .orElseThrow(() -> new BusinessException(ReplyErrorCode.NO_SUCH_REPLY));
+      for (Attach attach : attachList) {
+        attach.setReply(reply);
+      }
+    }
+
+    attachJpaRepository.saveAll(attachList);
+  }
+
+  private void validateInvalidInput(Long postId, Long replyId, int type) {
+    switch(type) {
+      case CREATE_FILES:
+        if (postId != null && replyId != null) {
+          throw new BusinessException(AttachErrorCode.INVALID_INPUT);
+        }
+        break;
+      case SET_FILES_OWNER:
+        if ((postId != null && replyId != null) || (postId == null && replyId == null)) {
+          throw new BusinessException(AttachErrorCode.INVALID_INPUT);
+        }
+        break;
+    }
   }
 
   private Attach getAttach(Long postId, Long replyId, MultipartFile multipartFile) {
     String fileOriginalName = multipartFile.getOriginalFilename();
-    if(postId != null) {
+    if (postId != null) {
       Post post = postJpaRepository.findById(postId)
-              .orElseThrow(() -> new BusinessException(PostErrorCode.NO_SUCH_POST));
+          .orElseThrow(() -> new BusinessException(PostErrorCode.NO_SUCH_POST));
       return new Attach(upload(multipartFile).getFileDownloadUrl(), fileOriginalName, post);
     }
 
-    if(replyId != null) {
+    if (replyId != null) {
       Reply reply = replyJpaRepository.findById(replyId)
-              .orElseThrow(() -> new BusinessException(ReplyErrorCode.NO_SUCH_REPLY));
-      return new Attach(upload(multipartFile).getFileDownloadUrl(), fileOriginalName, reply);
+          .orElseThrow(() -> new BusinessException(ReplyErrorCode.NO_SUCH_REPLY));
+      return new Attach("tempURL", fileOriginalName, reply);
+//      return new Attach(upload(multipartFile).getFileDownloadUrl(), fileOriginalName, reply);
     }
 
-    return new Attach(upload(multipartFile).getFileDownloadUrl(), fileOriginalName);
+    return new Attach("tempURL", fileOriginalName);
+//    return new Attach(upload(multipartFile).getFileDownloadUrl(), fileOriginalName);
   }
 
-  private MultipartFileUploadDto.Response upload(MultipartFile multipartFile){
+  private MultipartFileUploadDto.Response upload(MultipartFile multipartFile) {
     return multipartFileUploadService.upload(multipartFile);
   }
 }

--- a/src/main/java/com/se/apiserver/v1/attach/domain/entity/Attach.java
+++ b/src/main/java/com/se/apiserver/v1/attach/domain/entity/Attach.java
@@ -95,4 +95,8 @@ public class Attach extends BaseEntity {
     public void setReply(Reply reply) {
         this.reply = reply;
     }
+
+    public void setPost(Post post) {
+        this.post = post;
+    }
 }

--- a/src/main/java/com/se/apiserver/v1/attach/domain/entity/AttachCreateFuncType.java
+++ b/src/main/java/com/se/apiserver/v1/attach/domain/entity/AttachCreateFuncType.java
@@ -1,0 +1,5 @@
+package com.se.apiserver.v1.attach.domain.entity;
+
+public enum AttachCreateFuncType {
+  CREATE_FILES, SET_FILES_OWNER
+}

--- a/src/main/java/com/se/apiserver/v1/attach/infra/repository/AttachJpaRepository.java
+++ b/src/main/java/com/se/apiserver/v1/attach/infra/repository/AttachJpaRepository.java
@@ -12,4 +12,7 @@ public interface AttachJpaRepository extends JpaRepository<Attach, Long> {
 
   @Query("select a from Attach a where a.reply.replyId = :replyId")
   List<Attach> findAllByReplyId(Long replyId);
+
+  @Query("select a from Attach a where a.attachId in (:attachIdList)")
+  List<Attach> findAllByAttachId(List<Long> attachIdList);
 }

--- a/src/main/java/com/se/apiserver/v1/reply/application/dto/ReplyCreateDto.java
+++ b/src/main/java/com/se/apiserver/v1/reply/application/dto/ReplyCreateDto.java
@@ -1,22 +1,18 @@
 package com.se.apiserver.v1.reply.application.dto;
 
-import com.se.apiserver.v1.account.domain.entity.Account;
-import com.se.apiserver.v1.attach.domain.entity.Attach;
 import com.se.apiserver.v1.common.domain.entity.Anonymous;
-import com.se.apiserver.v1.post.domain.entity.Post;
-import com.se.apiserver.v1.reply.domain.entity.Reply;
-import com.se.apiserver.v1.reply.domain.entity.ReplyIsDelete;
 import com.se.apiserver.v1.reply.domain.entity.ReplyIsSecret;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.*;
-
-import javax.persistence.*;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.List;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Singular;
 
 public class ReplyCreateDto {
     @Data
@@ -45,10 +41,18 @@ public class ReplyCreateDto {
         @NotNull
         private ReplyIsSecret isSecret;
 
-        @ApiModelProperty(notes = "첨부파일들")
-        @Singular("attaches")
-        private List<AttachDto> attaches = new ArrayList<>();
+//        @ApiModelProperty(notes = "첨부파일들")
+//        @Singular("attaches")
+//        private List<AttachDto> attaches = new ArrayList<>();
     }
+
+//    @Data
+//    @NoArgsConstructor
+//    @AllArgsConstructor
+//    @Builder
+//    public static class AttachDto{
+//        private Long attachId;
+//    }
 
     @Data
     @NoArgsConstructor
@@ -56,6 +60,9 @@ public class ReplyCreateDto {
     @Builder
     public static class AttachDto{
         private Long attachId;
+        private String downloadUrl;
+        private String fileName;
+
     }
 }
 

--- a/src/main/java/com/se/apiserver/v1/reply/application/dto/ReplyCreateDto.java
+++ b/src/main/java/com/se/apiserver/v1/reply/application/dto/ReplyCreateDto.java
@@ -4,66 +4,53 @@ import com.se.apiserver.v1.common.domain.entity.Anonymous;
 import com.se.apiserver.v1.reply.domain.entity.ReplyIsSecret;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.ArrayList;
-import java.util.List;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Singular;
 
 public class ReplyCreateDto {
-    @Data
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Builder
-    @ApiModel(value = "댓글 생성 요청")
-    public static class Request{
-        @NotNull
-        @Min(1)
-        @ApiModelProperty(notes = "게시글 아이디", example = "1")
-        private Long postId;
 
-        @NotNull
-        @ApiModelProperty(notes = "댓글 내용", example = "string")
-        private String text;
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  @ApiModel(value = "댓글 생성 요청")
+  public static class Request {
 
-        @ApiModelProperty(notes = "익명 사용자 정보, 회원으로 등록일 경우 생략")
-        private Anonymous anonymous;
+    @NotNull
+    @Min(1)
+    @ApiModelProperty(notes = "게시글 아이디", example = "1")
+    private Long postId;
 
-        @Min(1)
-        @ApiModelProperty(notes = "부모 댓글의 번호")
-        private Long parentId;
+    @NotNull
+    @ApiModelProperty(notes = "댓글 내용", example = "string")
+    private String text;
 
-        @ApiModelProperty(notes = "비밀 여부")
-        @NotNull
-        private ReplyIsSecret isSecret;
+    @ApiModelProperty(notes = "익명 사용자 정보, 회원으로 등록일 경우 생략")
+    private Anonymous anonymous;
 
-//        @ApiModelProperty(notes = "첨부파일들")
-//        @Singular("attaches")
-//        private List<AttachDto> attaches = new ArrayList<>();
-    }
+    @Min(1)
+    @ApiModelProperty(notes = "부모 댓글의 번호")
+    private Long parentId;
 
-//    @Data
-//    @NoArgsConstructor
-//    @AllArgsConstructor
-//    @Builder
-//    public static class AttachDto{
-//        private Long attachId;
-//    }
+    @ApiModelProperty(notes = "비밀 여부")
+    @NotNull
+    private ReplyIsSecret isSecret;
+
 
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    public static class AttachDto{
-        private Long attachId;
-        private String downloadUrl;
-        private String fileName;
+    public static class AttachDto {
 
+      private Long attachId;
+      private String downloadUrl;
+      private String fileName;
     }
+  }
 }
-
 

--- a/src/main/java/com/se/apiserver/v1/reply/application/service/ReplyCreateService.java
+++ b/src/main/java/com/se/apiserver/v1/reply/application/service/ReplyCreateService.java
@@ -28,12 +28,12 @@ import org.springframework.web.multipart.MultipartFile;
 @Transactional(readOnly = true)
 public class ReplyCreateService {
 
-  private ReplyJpaRepository replyJpaRepository;
-  private PostJpaRepository postJpaRepository;
-  private AccountContextService accountContextService;
-  private AttachCreateService attachCreateService;
-  private AttachJpaRepository attachJpaRepository;
-  private PasswordEncoder passwordEncoder;
+  private final ReplyJpaRepository replyJpaRepository;
+  private final PostJpaRepository postJpaRepository;
+  private final AccountContextService accountContextService;
+  private final AttachCreateService attachCreateService;
+  private final AttachJpaRepository attachJpaRepository;
+  private final PasswordEncoder passwordEncoder;
 
   public ReplyCreateService(
       ReplyJpaRepository replyJpaRepository,
@@ -105,7 +105,7 @@ public class ReplyCreateService {
           .map(attach -> new AttachReadDto.Request(attach.getAttachId()))
           .collect(Collectors.toList());
 
-      attachCreateService.setFileOwner(null, reply.getReplyId(), requestList);
+      attachCreateService.setFilesOwner(null, reply.getReplyId(), requestList);
     }
 
     return reply.getReplyId();

--- a/src/main/java/com/se/apiserver/v1/reply/application/service/ReplyCreateService.java
+++ b/src/main/java/com/se/apiserver/v1/reply/application/service/ReplyCreateService.java
@@ -2,70 +2,122 @@ package com.se.apiserver.v1.reply.application.service;
 
 import com.se.apiserver.v1.account.application.service.AccountContextService;
 import com.se.apiserver.v1.account.domain.entity.Account;
+import com.se.apiserver.v1.attach.application.dto.AttachReadDto;
 import com.se.apiserver.v1.attach.application.error.AttachErrorCode;
+import com.se.apiserver.v1.attach.application.service.AttachCreateService;
 import com.se.apiserver.v1.attach.domain.entity.Attach;
 import com.se.apiserver.v1.attach.infra.repository.AttachJpaRepository;
-import com.se.apiserver.v1.authority.domain.entity.Authority;
 import com.se.apiserver.v1.common.domain.exception.BusinessException;
 import com.se.apiserver.v1.post.application.error.PostErrorCode;
 import com.se.apiserver.v1.post.domain.entity.Post;
 import com.se.apiserver.v1.post.infra.repository.PostJpaRepository;
 import com.se.apiserver.v1.reply.application.dto.ReplyCreateDto;
+import com.se.apiserver.v1.reply.application.dto.ReplyCreateDto.AttachDto;
 import com.se.apiserver.v1.reply.application.error.ReplyErrorCode;
 import com.se.apiserver.v1.reply.domain.entity.Reply;
 import com.se.apiserver.v1.reply.infra.repository.ReplyJpaRepository;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional(readOnly = true)
 public class ReplyCreateService {
-    private ReplyJpaRepository replyJpaRepository;
-    private PostJpaRepository postJpaRepository;
-    private AccountContextService accountContextService;
-    private AttachJpaRepository attachJpaRepository;
-    private PasswordEncoder passwordEncoder;
 
-    @Transactional
-    public Long create(ReplyCreateDto.Request request) {
-        Post post = postJpaRepository.findById(request.getPostId())
-                .orElseThrow(() -> new BusinessException(PostErrorCode.NO_SUCH_POST));
-        List<Attach> attachList = request.getAttaches().stream()
-                .map(attachDto -> {
-                    return attachJpaRepository.findById(attachDto.getAttachId())
-                            .orElseThrow(() -> new BusinessException(AttachErrorCode.NO_SUCH_ATTACH));
-                })
-                .collect(Collectors.toList());
-        Set<String> authorities = accountContextService.getContextAuthorities();
-        post.validateReadable();
-        post.getBoard().validateAccessAuthority(authorities);
-        Reply parent = getParent(request.getParentId());
-        String ip = accountContextService.getCurrentClientIP();
+  private ReplyJpaRepository replyJpaRepository;
+  private PostJpaRepository postJpaRepository;
+  private AccountContextService accountContextService;
+  private AttachCreateService attachCreateService;
+  private AttachJpaRepository attachJpaRepository;
+  private PasswordEncoder passwordEncoder;
 
-        if(accountContextService.isSignIn()){
-            Account account = accountContextService.getContextAccount();
-            Reply reply = new Reply(post,request.getText(), request.getIsSecret(), attachList, parent, ip, account);
-            replyJpaRepository.save(reply);
-            return reply.getReplyId();
-        }
+  public ReplyCreateService(
+      ReplyJpaRepository replyJpaRepository,
+      PostJpaRepository postJpaRepository,
+      AccountContextService accountContextService,
+      AttachCreateService attachCreateService,
+      AttachJpaRepository attachJpaRepository,
+      PasswordEncoder passwordEncoder) {
+    this.replyJpaRepository = replyJpaRepository;
+    this.postJpaRepository = postJpaRepository;
+    this.accountContextService = accountContextService;
+    this.attachCreateService = attachCreateService;
+    this.attachJpaRepository = attachJpaRepository;
+    this.passwordEncoder = passwordEncoder;
+  }
 
-        request.getAnonymous().setAnonymousPassword(passwordEncoder.encode(request.getAnonymous().getAnonymousPassword()));
-        Reply reply = new Reply(post,request.getText(), request.getIsSecret(), attachList, parent, ip, request.getAnonymous());
-        replyJpaRepository.save(reply);
-        return reply.getReplyId();
+  @Transactional
+  public Long create(ReplyCreateDto.Request request, MultipartFile[] files) {
+    List<Attach> attachList = null;
+
+    if (files != null) {
+      List<AttachDto> attachDtoList
+          = attachCreateService.createFiles(null, null, files)
+          .stream()
+          .map(
+              dto -> AttachDto.builder()
+                  .attachId(dto.getAttachId())
+                  .downloadUrl(dto.getDownloadUrl())
+                  .fileName(dto.getFileName())
+                  .build())
+          .collect(Collectors.toList());
+      attachList
+          = attachDtoList
+          .stream()
+          .map(dto -> attachJpaRepository.findById(dto.getAttachId())
+              .orElseThrow(() -> new BusinessException(AttachErrorCode.NO_SUCH_ATTACH)))
+          .collect(Collectors.toList());
     }
 
-    private Reply getParent(Long parentId) {
-        if(parentId == null)
-            return null;
+    Post post = postJpaRepository.findById(request.getPostId())
+        .orElseThrow(() -> new BusinessException(PostErrorCode.NO_SUCH_POST));
 
-        Reply parent = replyJpaRepository.findById(parentId)
-                .orElseThrow(() -> new BusinessException(ReplyErrorCode.NO_SUCH_REPLY));
-        return parent;
+    Set<String> authorities = accountContextService.getContextAuthorities();
+    post.validateReadable();
+    post.getBoard().validateAccessAuthority(authorities);
+
+    Reply parent = getParent(request.getParentId());
+    String ip = accountContextService.getCurrentClientIP();
+
+    Reply reply;
+
+    if (accountContextService.isSignIn()) {
+      Account account = accountContextService.getContextAccount();
+      reply = new Reply(post, request.getText(), request.getIsSecret(), attachList, parent,
+          ip, account);
+    } else {
+      request.getAnonymous().setAnonymousPassword(
+          passwordEncoder.encode(request.getAnonymous().getAnonymousPassword()));
+      reply = new Reply(post, request.getText(), request.getIsSecret(), attachList, parent, ip,
+          request.getAnonymous());
     }
+
+    replyJpaRepository.save(reply);
+
+    if (attachList != null) {
+      List<AttachReadDto.Request> requestList
+          = attachList
+          .stream()
+          .map(attach -> new AttachReadDto.Request(attach.getAttachId()))
+          .collect(Collectors.toList());
+
+      attachCreateService.setFileOwner(null, reply.getReplyId(), requestList);
+    }
+
+    return reply.getReplyId();
+  }
+
+  private Reply getParent(Long parentId) {
+    if (parentId == null) {
+      return null;
+    }
+
+    Reply parent = replyJpaRepository.findById(parentId)
+        .orElseThrow(() -> new BusinessException(ReplyErrorCode.NO_SUCH_REPLY));
+    return parent;
+  }
 }

--- a/src/main/java/com/se/apiserver/v1/reply/infra/api/ReplyApiController.java
+++ b/src/main/java/com/se/apiserver/v1/reply/infra/api/ReplyApiController.java
@@ -15,60 +15,70 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
 @Api(tags = "댓글 관리")
 public class ReplyApiController {
-    private final ReplyCreateService replyCreateService;
-    private final ReplyDeleteService replyDeleteService;
-    private final ReplyUpdateService replyUpdateService;
-    private final ReplyReadService replyReadService;
 
-    @PostMapping(value = "/reply")
-    @ResponseStatus(HttpStatus.CREATED)
-    @ApiOperation(value = "댓글 생성")
-    public SuccessResponse<Long> create(@RequestBody @Validated ReplyCreateDto.Request request){
-        return new SuccessResponse<>(HttpStatus.CREATED.value(), "성공적으로 등록되었습니다", replyCreateService.create(request));
-    }
+  private final ReplyCreateService replyCreateService;
+  private final ReplyDeleteService replyDeleteService;
+  private final ReplyUpdateService replyUpdateService;
+  private final ReplyReadService replyReadService;
 
-    @PutMapping("/reply")
-    @ResponseStatus(HttpStatus.OK)
-    @ApiOperation("댓글 수정")
-    public SuccessResponse<Long> update(@RequestBody @Validated ReplyUpdateDto.Request request){
-        return new SuccessResponse<>(HttpStatus.OK.value(), "성공적으로 수정되었습니다", replyUpdateService.update(request));
-    }
+  @PostMapping(value = "/reply")
+  @ResponseStatus(HttpStatus.CREATED)
+  @ApiOperation(value = "댓글 생성")
+  public SuccessResponse<Long> create(
+      @RequestPart(value = "key") @Validated ReplyCreateDto.Request request,
+      @RequestPart(value = "files", required = false) MultipartFile[] files) {
+    return new SuccessResponse<>(HttpStatus.CREATED.value(), "성공적으로 등록되었습니다",
+        replyCreateService.create(request, files));
+  }
 
-    @DeleteMapping("/reply/{id}")
-    @ResponseStatus(HttpStatus.OK)
-    @ApiOperation("댓글 삭제")
-    public SuccessResponse delete(@PathVariable(value = "id") Long replyId){
-        replyDeleteService.delete(replyId);
-        return new SuccessResponse(HttpStatus.OK.value(), "성공적으로 삭제되었습니다");
-    }
+  @PutMapping("/reply")
+  @ResponseStatus(HttpStatus.OK)
+  @ApiOperation("댓글 수정")
+  public SuccessResponse<Long> update(@RequestBody @Validated ReplyUpdateDto.Request request) {
+    return new SuccessResponse<>(HttpStatus.OK.value(), "성공적으로 수정되었습니다",
+        replyUpdateService.update(request));
+  }
 
-    @DeleteMapping("/reply/anonymous")
-    @ResponseStatus(HttpStatus.OK)
-    @ApiOperation("댓글 삭제")
-    public SuccessResponse delete(@RequestBody @Validated ReplyDeleteDto.AnonymousReplyDeleteRequest anonymousReplyDeleteRequest){
-        replyDeleteService.deleteAnonymousReply(anonymousReplyDeleteRequest);
-        return new SuccessResponse(HttpStatus.OK.value(), "성공적으로 삭제되었습니다");
-    }
+  @DeleteMapping("/reply/{id}")
+  @ResponseStatus(HttpStatus.OK)
+  @ApiOperation("댓글 삭제")
+  public SuccessResponse delete(@PathVariable(value = "id") Long replyId) {
+    replyDeleteService.delete(replyId);
+    return new SuccessResponse(HttpStatus.OK.value(), "성공적으로 삭제되었습니다");
+  }
 
-    @GetMapping("/reply/{reply_id}")
-    @ResponseStatus(HttpStatus.OK)
-    @ApiOperation("댓글 단일 조회")
-    public SuccessResponse<ReplyReadDto.Response> read(@PathVariable(value = "reply_id") Long replyId){
-        return new SuccessResponse<>(HttpStatus.CREATED.value(), "성공적으로 조회되었습니다", replyReadService.read(replyId));
-    }
+  @DeleteMapping("/reply/anonymous")
+  @ResponseStatus(HttpStatus.OK)
+  @ApiOperation("댓글 삭제")
+  public SuccessResponse delete(
+      @RequestBody @Validated ReplyDeleteDto.AnonymousReplyDeleteRequest anonymousReplyDeleteRequest) {
+    replyDeleteService.deleteAnonymousReply(anonymousReplyDeleteRequest);
+    return new SuccessResponse(HttpStatus.OK.value(), "성공적으로 삭제되었습니다");
+  }
 
-    @GetMapping("/reply/post/{post_id}")
-    @ResponseStatus(HttpStatus.OK)
-    @ApiOperation("댓글 리스트 조회")
-    public SuccessResponse<List<ReplyReadDto.Response>> readAllBelongPost(@PathVariable(value = "post_id") Long postId){
-        return new SuccessResponse<>(HttpStatus.CREATED.value(), "성공적으로 조회되었습니다", replyReadService.readAllBelongPost(postId));
-    }
+  @GetMapping("/reply/{reply_id}")
+  @ResponseStatus(HttpStatus.OK)
+  @ApiOperation("댓글 단일 조회")
+  public SuccessResponse<ReplyReadDto.Response> read(
+      @PathVariable(value = "reply_id") Long replyId) {
+    return new SuccessResponse<>(HttpStatus.CREATED.value(), "성공적으로 조회되었습니다",
+        replyReadService.read(replyId));
+  }
+
+  @GetMapping("/reply/post/{post_id}")
+  @ResponseStatus(HttpStatus.OK)
+  @ApiOperation("댓글 리스트 조회")
+  public SuccessResponse<List<ReplyReadDto.Response>> readAllBelongPost(
+      @PathVariable(value = "post_id") Long postId) {
+    return new SuccessResponse<>(HttpStatus.CREATED.value(), "성공적으로 조회되었습니다",
+        replyReadService.readAllBelongPost(postId));
+  }
 }

--- a/src/test/java/com/se/apiserver/v1/reply/application/service/ReplyCreateServiceTest.java
+++ b/src/test/java/com/se/apiserver/v1/reply/application/service/ReplyCreateServiceTest.java
@@ -1,0 +1,330 @@
+package com.se.apiserver.v1.reply.application.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.se.apiserver.v1.account.application.service.AccountContextService;
+import com.se.apiserver.v1.account.domain.entity.Account;
+import com.se.apiserver.v1.account.domain.entity.AccountType;
+import com.se.apiserver.v1.account.domain.entity.InformationOpenAgree;
+import com.se.apiserver.v1.account.domain.entity.Question;
+import com.se.apiserver.v1.attach.application.dto.AttachReadDto;
+import com.se.apiserver.v1.attach.application.dto.AttachReadDto.Response;
+import com.se.apiserver.v1.attach.application.error.AttachErrorCode;
+import com.se.apiserver.v1.attach.application.service.AttachCreateService;
+import com.se.apiserver.v1.attach.domain.entity.Attach;
+import com.se.apiserver.v1.attach.infra.repository.AttachJpaRepository;
+import com.se.apiserver.v1.board.domain.entity.Board;
+import com.se.apiserver.v1.common.domain.entity.Anonymous;
+import com.se.apiserver.v1.common.domain.exception.BusinessException;
+import com.se.apiserver.v1.post.application.error.PostErrorCode;
+import com.se.apiserver.v1.post.domain.entity.Post;
+import com.se.apiserver.v1.post.domain.entity.PostContent;
+import com.se.apiserver.v1.post.domain.entity.PostIsNotice;
+import com.se.apiserver.v1.post.domain.entity.PostIsSecret;
+import com.se.apiserver.v1.post.infra.repository.PostJpaRepository;
+import com.se.apiserver.v1.reply.application.dto.ReplyCreateDto;
+import com.se.apiserver.v1.reply.application.dto.ReplyCreateDto.AttachDto;
+import com.se.apiserver.v1.reply.application.dto.ReplyCreateDto.Request;
+import com.se.apiserver.v1.reply.application.error.ReplyErrorCode;
+import com.se.apiserver.v1.reply.domain.entity.Reply;
+import com.se.apiserver.v1.reply.domain.entity.ReplyIsSecret;
+import com.se.apiserver.v1.reply.infra.repository.ReplyJpaRepository;
+import com.se.apiserver.v1.tag.domain.entity.Tag;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+public class ReplyCreateServiceTest {
+
+  @Mock
+  private ReplyJpaRepository replyJpaRepository;
+
+  @Mock
+  private PostJpaRepository postJpaRepository;
+
+  @Mock
+  private AccountContextService accountContextService;
+
+  @Mock
+  private AttachJpaRepository attachJpaRepository;
+
+  @Mock
+  private PasswordEncoder passwordEncoder;
+
+  @Mock
+  private AttachCreateService attachCreateService;
+
+  @InjectMocks
+  private ReplyCreateService replyCreateService;
+
+  MultipartFile[] files = new MultipartFile[1];
+
+  @Test
+  void 회원_댓글_등록_성공() {
+    // given
+    Long postId = 1L;
+    List<AttachReadDto.Response> attachResponseList
+        = Arrays.asList(AttachReadDto.Response.builder().attachId(1L).build());
+    List<AttachDto> attachs = Arrays.asList(new AttachDto(1L, null, null));
+    ReplyCreateDto.Request request = ReplyCreateDto.Request.builder()
+        .postId(postId)
+        .text("4학년 / 20180764 윤진")
+        .isSecret(ReplyIsSecret.NORMAL)
+        .build();
+    Post post = getPost();
+    Account account = getAccount();
+    Reply reply = new Reply(post
+        , request.getText()
+        , request.getIsSecret()
+        , null
+        , null
+        , "127.0.0.1"
+        , account);
+
+
+    Set<String> authorities = new HashSet<>(Arrays.asList("FREEBOARD_ACCESS"));
+
+    given(attachCreateService.createFiles(null, null, files)).willReturn(attachResponseList);
+    given(postJpaRepository.findById(postId)).willReturn(java.util.Optional.of(post));
+    given(attachJpaRepository.findById(attachs.get(0).getAttachId())).willReturn(
+        Optional.of(new Attach("url", "name", reply)));
+    given(accountContextService.getContextAuthorities()).willReturn(authorities);
+    given(accountContextService.isSignIn()).willReturn(true);
+    given(accountContextService.getContextAccount()).willReturn(account);
+    given(replyJpaRepository.save(Mockito.any(Reply.class))).willReturn(reply);
+
+    // when, then
+    assertDoesNotThrow(() -> replyCreateService.create(request, files));
+  }
+
+  @Test
+  void 익명_사용자_댓글_등록_성공() {
+    // given
+    Long postId = 1L;
+    List<AttachReadDto.Response> attachResponseList
+        = Arrays.asList(AttachReadDto.Response.builder().attachId(1L).build());
+    List<AttachDto> attachs = Arrays.asList(new AttachDto(1L, null, null));
+    Anonymous anonymous = getAnonymous();
+    ReplyCreateDto.Request request = ReplyCreateDto.Request.builder()
+        .postId(postId)
+        .text("4학년 / 20180764 윤진")
+        .anonymous(anonymous)
+        .isSecret(ReplyIsSecret.NORMAL)
+        .build();
+    Post post = getPost();
+    List<Attach> attachList = new ArrayList<>();
+    Reply reply = new Reply(post
+        , request.getText()
+        , request.getIsSecret()
+        , attachList
+        , null,
+        "127.0.0.1"
+        , anonymous);
+    Set<String> authorities = new HashSet<>(Arrays.asList("FREEBOARD_ACCESS"));
+
+    given(attachCreateService.createFiles(null, null, files)).willReturn(attachResponseList);
+    given(postJpaRepository.findById(postId)).willReturn(java.util.Optional.of(post));
+    given(attachJpaRepository.findById(attachs.get(0).getAttachId())).willReturn(
+        Optional.of(new Attach("url", "name", reply)));
+    given(accountContextService.getContextAuthorities()).willReturn(authorities);
+    given(accountContextService.isSignIn()).willReturn(false);
+    given(replyJpaRepository.save(Mockito.any(Reply.class))).willReturn(reply);
+    given(passwordEncoder.encode(request.getAnonymous().getAnonymousPassword())).willReturn("iDonTKnOw!@#");
+
+    // when, then
+    assertDoesNotThrow(() -> replyCreateService.create(request, files));
+  }
+
+  @Test
+  void 대댓글_등록할_때_부모_댓글_존재하지_않는_경우()
+      throws NoSuchMethodException {
+    // given
+    Long nonExistentReplyId = 1L;
+    given(replyJpaRepository.findById(nonExistentReplyId)).willThrow(new BusinessException(
+        ReplyErrorCode.NO_SUCH_REPLY));
+    Method method = replyCreateService.getClass().getDeclaredMethod("getParent", Long.class);
+    method.setAccessible(true);
+
+    // when
+    InvocationTargetException invocationTargetException = assertThrows(InvocationTargetException.class,
+        () -> method.invoke(replyCreateService, nonExistentReplyId));
+    BusinessException businessException = (BusinessException) invocationTargetException.getTargetException();
+
+    // then
+    assertThat(businessException.getErrorCode(), is(ReplyErrorCode.NO_SUCH_REPLY));
+    assertThat(businessException.getMessage(), is("존재하지 않는 댓글"));
+  }
+
+  @Test
+  void 존재하지_않는_첨부파일() {
+    // given
+    Long postId = 1L;
+    Long replyId = 1L;
+    String text = "4학년 / 20180764 윤진";
+    List<AttachDto> attachs = Arrays.asList(new AttachDto(2L, null, null));
+    List<AttachReadDto.Response> attachResponseList
+        = Arrays.asList(AttachReadDto.Response.builder().attachId(1L).build());
+    ReplyCreateDto.Request request = ReplyCreateDto.Request.builder()
+        .postId(postId)
+        .text(text)
+        .isSecret(ReplyIsSecret.NORMAL)
+        .build();
+    Post post = getPost();
+
+    given(postJpaRepository.findById(postId)).willReturn(java.util.Optional.of(post));
+    given(attachCreateService.createFiles(null, null, files)).willReturn(attachResponseList);
+    given(attachJpaRepository.findById(Mockito.any(Long.class)))
+        .willThrow(new BusinessException(AttachErrorCode.NO_SUCH_ATTACH));
+
+    // when
+    BusinessException businessException = assertThrows(BusinessException.class,
+        () -> replyCreateService.create(request, files));
+
+    // then
+    assertThat(businessException.getErrorCode(), is(AttachErrorCode.NO_SUCH_ATTACH));
+    assertThat(businessException.getMessage(), is("존재하지 않는 첨부파일"));
+  }
+
+  @Test
+  void 존재하지_않는_게시글() {
+    // given
+    Long nonExistentPostId = 2L;
+    String text = "4학년 / 20180764 윤진";
+    ReplyCreateDto.Request request = ReplyCreateDto.Request.builder()
+        .postId(nonExistentPostId)
+        .text(text)
+        .isSecret(ReplyIsSecret.NORMAL)
+        .build();
+    given(postJpaRepository.findById(nonExistentPostId))
+        .willThrow(new BusinessException(PostErrorCode.NO_SUCH_POST));
+
+    // when
+    BusinessException businessException = assertThrows(BusinessException.class,
+        () -> replyCreateService
+            .create(request, files));
+
+    // then
+    assertThat(businessException.getErrorCode(), is(PostErrorCode.NO_SUCH_POST));
+    assertThat(businessException.getMessage(), is("존재하지 않는 게시글"));
+  }
+
+  @Test
+  void 접근_권한이_없는_게시판() {
+    // given
+    Post post = getPost();
+    Long postId = 1L;
+    String text = "4학년 / 20180764 윤진";
+    Request request = Request.builder()
+        .postId(postId)
+        .text(text)
+        .isSecret(ReplyIsSecret.NORMAL)
+        .build();
+    given(postJpaRepository.findById(postId)).willReturn(Optional.of(post));
+
+    // when
+    AccessDeniedException accessDeniedException = assertThrows(AccessDeniedException.class,
+        () -> replyCreateService.create(request, files));
+
+    // then
+    assertThat(accessDeniedException.getMessage(), is("접근 권한이 없습니다"));
+  }
+
+  @Test
+  void 삭제된_게시글() {
+    // given
+    Post post = getPost();
+    post.delete();
+    Long postId = 1L;
+    String text = "4학년 / 20180764 윤진";
+    ReplyCreateDto.Request request = ReplyCreateDto.Request.builder()
+        .postId(postId)
+        .text(text)
+        .isSecret(ReplyIsSecret.NORMAL)
+        .build();
+    Set<String> authorities = new HashSet<>(Arrays.asList("FREEBOARD_ACCESS"));
+
+    given(postJpaRepository.findById(postId)).willReturn(java.util.Optional.of(post));
+    given(accountContextService.getContextAuthorities()).willReturn(authorities);
+
+    // when
+    BusinessException businessException = assertThrows(BusinessException.class,
+        () -> replyCreateService.create(request, files));
+
+    // then
+    assertThat(businessException.getMessage(), is("삭제된 게시글입니다"));
+    assertThat(businessException.getErrorCode(), is(PostErrorCode.DELETED_POST));
+  }
+
+  private Anonymous getAnonymous() {
+    String anonymousNickName = "ㅇㅇ";
+    String anonymousPassword = "qwerty";
+    return new Anonymous(anonymousNickName, anonymousPassword);
+  }
+
+  private Account getAccount() {
+    Long accountId = 1L;
+    String idString = "jduck1024";
+    String password = "1234";
+    String name = "윤진";
+    String nickname = "오리";
+    String studentId = "20180764";
+    AccountType accountType = AccountType.STUDENT;
+    String phoneNumber = "01012345678";
+    String email = "20180764@kumoh.ac.kr";
+    String lastSingInIp = "127.0.0.1";
+    InformationOpenAgree informationOpenAgree = InformationOpenAgree.AGREE;
+    Question question = null;
+    String answer = null;
+
+    return new Account(accountId, idString, password, name, nickname, studentId, accountType,
+        phoneNumber, email, lastSingInIp, informationOpenAgree, question, answer);
+  }
+
+  private Board getBoard() {
+    String nameEng = "FREEBOARD";
+    String nameKor = "자유게시판";
+
+    return new Board(nameEng, nameKor);
+  }
+
+  private PostContent getPostContent() {
+    String title = "학생회 특식 배부";
+    String text = "양식 : 학년 / 학번 이름";
+
+    return new PostContent(title, text);
+  }
+
+  private Post getPost() {
+    Account account = getAccount();
+    Board board = getBoard();
+    PostContent postContent = getPostContent();
+    Set<String> authorities = new HashSet<>(Arrays.asList("FREEBOARD_ACCESS"));
+    List<Tag> tags = new ArrayList<>();
+    List<Attach> attaches = new ArrayList<>();
+    String createdIp = "127.0.0.1";
+
+    return new Post(account, board, postContent, PostIsNotice.NORMAL, PostIsSecret.NORMAL,
+        authorities, tags, attaches, createdIp);
+  }
+}


### PR DESCRIPTION
# Pull Request Check List
- Major Reviewer: @KitTeamSe/be 

## CheckList

- [ ] Unit test coverage
- [ ] Backward compatibility
- [ ] Tested on dev/staging environment
- [ ] Documentation
- [x] Self reviewed

## Context
- 댓글 및 첨부파일 생성 시 한 트랜잭션으로 처리하도록 수정
  - ReplyCreateService의 create 내에서 Attach 등록 -> Reply 등록 -> Attach의 Reply 업데이트 과정이 이루어짐.
- 다중 첨부 파일 저장 메소드 추가(AttachCreateService)
- 첨부 파일 및 댓글(게시물) 저장 후 첨부파일 Reply(Post) 업데이트 메소드 추가(AttachCreateService)