### PR TITLE
[KIT-120] 댓글 테스트 작성 및 트러블슈팅 / 댓글 수정 리팩토링

### DIFF
--- a/src/main/java/com/se/apiserver/v1/attach/application/service/AttachDeleteService.java
+++ b/src/main/java/com/se/apiserver/v1/attach/application/service/AttachDeleteService.java
@@ -50,21 +50,6 @@ public class AttachDeleteService {
   }
 
   @Transactional
-  public boolean deleteAll(List<Long> idList) {
-    List<Attach> attachList = attachJpaRepository.findAllByAttachId(idList);
-    String[] saveNames = new String[attachList.size()];
-
-    for (Attach attach : attachList) {
-      saveNames[attachList.indexOf(attach)] = attach.getSaveName();
-      attach.remove();
-    }
-
-    attachJpaRepository.deleteAll(attachList);
-//    multipartFileDeleteService.delete(saveNames);
-    return true;
-  }
-
-  @Transactional
   public boolean deleteAllByOwnerId(Long postId, Long replyId) {
     validateInvalidInput(postId, replyId);
 

--- a/src/main/java/com/se/apiserver/v1/attach/infra/repository/AttachJpaRepository.java
+++ b/src/main/java/com/se/apiserver/v1/attach/infra/repository/AttachJpaRepository.java
@@ -21,12 +21,12 @@ public interface AttachJpaRepository extends JpaRepository<Attach, Long> {
   List<Attach> findAllByAttachId(List<Long> attachIdList);
 
   @Transactional
-  @Modifying
+  @Modifying(clearAutomatically = true)
   @Query("delete from Attach a where a.post.postId = :postId")
   void deleteAttachesByPostId(Long postId);
 
   @Transactional
-  @Modifying
+  @Modifying(clearAutomatically = true)
   @Query("delete from Attach a where a.reply.replyId = :replyId")
   void deleteAttachesByReplyId(Long replyId);
 }

--- a/src/main/java/com/se/apiserver/v1/reply/application/dto/ReplyUpdateDto.java
+++ b/src/main/java/com/se/apiserver/v1/reply/application/dto/ReplyUpdateDto.java
@@ -38,9 +38,5 @@ public class ReplyUpdateDto {
         @ApiModelProperty(notes = "비밀 여부")
         @NotNull
         private ReplyIsSecret isSecret;
-
-        @ApiModelProperty(notes = "첨부파일들")
-        @Singular("attaches")
-        private List<Long> attachIdList = new ArrayList<>();
     }
 }

--- a/src/main/java/com/se/apiserver/v1/reply/application/service/ReplyCreateService.java
+++ b/src/main/java/com/se/apiserver/v1/reply/application/service/ReplyCreateService.java
@@ -80,7 +80,7 @@ public class ReplyCreateService {
   private void createAttaches(Reply reply, MultipartFile[] files) {
     if (files != null) {
       List<Long> attachIdList = attachCreateService.createAttaches(null, reply.getReplyId(), files);
-      reply.updateAttaches(attachJpaRepository.findAllByAttachId(attachIdList));
+      reply.updateAttaches(attachJpaRepository.findAllByReplyId(reply.getReplyId()));
     }
   }
 

--- a/src/main/java/com/se/apiserver/v1/reply/application/service/ReplyUpdateService.java
+++ b/src/main/java/com/se/apiserver/v1/reply/application/service/ReplyUpdateService.java
@@ -71,7 +71,7 @@ public class ReplyUpdateService {
     updateReplyIsSecretIfNotNull(reply, request.getIsSecret());
     updateLastModifiedIp(reply, accountContextService.getCurrentClientIP());
 
-    attachDeleteService.deleteAll(request.getAttachIdList());
+    attachDeleteService.deleteAllByOwnerId(null, reply.getReplyId());
 
     replyJpaRepository.save(reply);
     updateAttaches(reply, files);
@@ -85,8 +85,8 @@ public class ReplyUpdateService {
 
   private void updateAttaches(Reply reply, MultipartFile[] files) {
     if (files != null) {
-      List<Long> attachIdList = attachCreateService.createAttaches(null, reply.getReplyId(), files);
-      reply.updateAttaches(attachJpaRepository.findAllByAttachId(attachIdList));
+      attachCreateService.createAttaches(null, reply.getReplyId(), files);
+      reply.updateAttaches(attachJpaRepository.findAllByReplyId(reply.getReplyId()));
     }
   }
 

--- a/src/main/java/com/se/apiserver/v1/reply/domain/entity/Reply.java
+++ b/src/main/java/com/se/apiserver/v1/reply/domain/entity/Reply.java
@@ -118,7 +118,8 @@ public class Reply extends BaseEntity {
     if (attaches == null) {
       return;
     }
-    this.attaches = new HashSet<>(attaches);
+    this.attaches.clear();
+    this.attaches.addAll(attaches);
   }
 
   private void validateAnonymousInput(Anonymous anonymous) {


### PR DESCRIPTION
- 댓글 등록 및 수정에서 사용되는 부분
- in 연산자 대신 = 사용

# Pull Request Check List
- Major Reviewer: @KitTeamSe/be 

## CheckList

- [ ] Unit test coverage
- [ ] Backward compatibility
- [ ] Tested on dev/staging environment
- [ ] Documentation
- [x] Self reviewed

## Context
- 첨부 파일 조회 및 삭제 개선
- attachId 리스트를 이용해 in 연산자로 조회 -> replyId를 이용해 =으로 조회