### PR TITLE
[KIT-114] 임시 LogStack 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ out/
 ### properties ###
 *.yml
 !.drone.yml
+
+### logs ###
+/logs/

--- a/src/main/java/com/se/apiserver/v1/common/application/dto/request/BaseRequest.java
+++ b/src/main/java/com/se/apiserver/v1/common/application/dto/request/BaseRequest.java
@@ -1,4 +1,4 @@
-package com.se.apiserver.v1.common.application;
+package com.se.apiserver.v1.common.application.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import io.swagger.annotations.ApiModelProperty;

--- a/src/main/java/com/se/apiserver/v1/common/infra/advice/SeExceptionAdvice.java
+++ b/src/main/java/com/se/apiserver/v1/common/infra/advice/SeExceptionAdvice.java
@@ -21,7 +21,9 @@ package com.se.apiserver.v1.common.infra.advice;
  *  modified by dldhk97
  */
 
-import com.se.apiserver.v1.common.application.dto.ExceptionResponse;
+import com.se.apiserver.v1.common.infra.logging.SeLogger;
+import com.se.apiserver.v1.common.infra.logging.standard.SeStandardLogger;
+import com.se.apiserver.v1.common.presentation.response.ExceptionResponse;
 import com.se.apiserver.v1.common.domain.exception.PreconditionFailedException;
 import com.se.apiserver.v1.common.domain.exception.SeException;
 import javax.validation.ConstraintViolationException;
@@ -31,21 +33,17 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-//TODO : 에러 컨벤션 확보 필요
 @RestControllerAdvice
 public class SeExceptionAdvice {
 
-  @ExceptionHandler(Exception.class)
-  public ResponseEntity<ExceptionResponse> handleSeException(final SeException e){
-    this.countExceptionAndLog(e);
-    HttpStatus status = e.getHttpStatus();
-    if(status == null)
-      status = HttpStatus.INTERNAL_SERVER_ERROR;
-    return new ResponseEntity<>(ExceptionResponse.of(e), status);
+  private final SeLogger logger;
+
+  public SeExceptionAdvice() {
+    this.logger = new SeStandardLogger();
   }
 
   @ExceptionHandler(SeException.class)
-  public ResponseEntity<ExceptionResponse> handleGenieCheckedException(final SeException e) {
+  public ResponseEntity<ExceptionResponse> handleSeException(final SeException e) {
     this.countExceptionAndLog(e);
     if (e.getHttpStatus() == null)
       return new ResponseEntity<>(ExceptionResponse.of(e), HttpStatus.INTERNAL_SERVER_ERROR);
@@ -61,18 +59,8 @@ public class SeExceptionAdvice {
     );
   }
 
-  @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<PreconditionFailedException> handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
-    this.countExceptionAndLog(e);
-    return new ResponseEntity<>(
-        new PreconditionFailedException(e.getMessage(), e),
-        HttpStatus.PRECONDITION_FAILED
-    );
-  }
-
   private void countExceptionAndLog(final Exception e) {
-    // TODO: Stack trace 등의 정보는 로그 스택에 저장
-//    log.error("{}: {}", e.getClass().getSimpleName(), e.getLocalizedMessage());
-//    log.debug("{}: {}", e.getClass().getCanonicalName(), e.getMessage(), e);
+    logger.error(e.getClass().getSimpleName(), e.getMessage());
+    logger.debug(e.getClass().getSimpleName(), e.getMessage(), e);
   }
 }

--- a/src/main/java/com/se/apiserver/v1/common/infra/logging/SeLogger.java
+++ b/src/main/java/com/se/apiserver/v1/common/infra/logging/SeLogger.java
@@ -1,0 +1,25 @@
+package com.se.apiserver.v1.common.infra.logging;
+
+/**
+ * 로그 스택을 용이하게 변경하기 위한 로거 인터페이스
+ * 로그 레벨에 따라 FATAL > ERROR >WARN > INFO > DEBUG > TRACE 순으로 로깅됩니다.
+ * 만약 디버그 레벨이 DEBUG 라면 FATAL ~ DEBUG 까지 모두 로깅이 됩니다.
+ */
+public interface SeLogger {
+
+  // 요청을 처리하는 중 문제가 발생한 상태.
+  void error(String className, String msg);
+  void error(String className, String msg, Throwable t);
+
+  // 처리 가능한 문제이지만, 향후 에러의 원인이 될 수 있음.
+  void warn(String className, String msg);
+  void warn(String className, String msg, Throwable t);
+
+  // 로그인, 상태 변경과 같은 정보성 메시지 표시.
+  void info(String className, String msg);
+  void info(String className, String msg, Throwable t);
+
+  // 개발 시 디버그 용도로 사용.
+  void debug(String className, String msg);
+  void debug(String className, String msg, Throwable t);
+}

--- a/src/main/java/com/se/apiserver/v1/common/infra/logging/standard/SeStandardLogger.java
+++ b/src/main/java/com/se/apiserver/v1/common/infra/logging/standard/SeStandardLogger.java
@@ -1,0 +1,59 @@
+package com.se.apiserver.v1.common.infra.logging.standard;
+
+import com.se.apiserver.v1.common.infra.logging.SeLogger;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Slf4j
+public class SeStandardLogger implements SeLogger {
+  private final Logger logger;
+
+  public SeStandardLogger() {
+    this.logger = LoggerFactory.getLogger(this.getClass());
+  }
+
+  @Override
+  public void error(String className, String msg) {
+    logger.error("{} : {}", className, msg);
+  }
+
+  @Override
+  public void error(String className, String msg, Throwable t) {
+    logger.error("{} : {}", className, msg, t);
+  }
+
+  @Override
+  public void warn(String className, String msg) {
+    logger.warn("{} : {}", className, msg);
+  }
+
+  @Override
+  public void warn(String className, String msg, Throwable t) {
+    logger.warn("{} : {}", className, msg, t);
+  }
+
+  @Override
+  public void info(String className, String msg) {
+    logger.info("{} : {}", className, msg);
+  }
+
+  @Override
+  public void info(String className, String msg, Throwable t) {
+    logger.info("{} : {}", className, msg, t);
+  }
+
+  @Override
+  public void debug(String className, String msg){
+    if(logger.isDebugEnabled()){
+      logger.debug("{} : {}", className, msg);
+    }
+  }
+
+  @Override
+  public void debug(String className, String msg, Throwable t) {
+    if(logger.isDebugEnabled()){
+      logger.debug("{} : {}", className, msg, t);
+    }
+  }
+}

--- a/src/main/java/com/se/apiserver/v1/common/infra/springboot/advice/GlobalControllerAdvice.java
+++ b/src/main/java/com/se/apiserver/v1/common/infra/springboot/advice/GlobalControllerAdvice.java
@@ -6,6 +6,8 @@ import com.se.apiserver.v1.common.domain.error.ErrorCode;
 import com.se.apiserver.v1.common.domain.error.GlobalErrorCode;
 import com.se.apiserver.v1.common.domain.exception.BusinessException;
 import com.se.apiserver.v1.common.infra.dto.ErrorResponse;
+import com.se.apiserver.v1.common.infra.logging.SeLogger;
+import com.se.apiserver.v1.common.infra.logging.standard.SeStandardLogger;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,14 +23,22 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 @Slf4j
 public class GlobalControllerAdvice {
 
+  private final SeLogger logger;
+
+  public GlobalControllerAdvice() {
+    this.logger = new SeStandardLogger();
+  }
+
   @ExceptionHandler(MethodArgumentNotValidException.class)
   protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    countExceptionAndLog(e);
     final ErrorResponse response = ErrorResponse.of(GlobalErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
     return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
   }
 
   @ExceptionHandler(BindException.class)
   protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+    countExceptionAndLog(e);
     final ErrorResponse response = ErrorResponse.of(GlobalErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
     return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
   }
@@ -36,6 +46,7 @@ public class GlobalControllerAdvice {
   @ExceptionHandler(MethodArgumentTypeMismatchException.class)
   protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
       MethodArgumentTypeMismatchException e) {
+    countExceptionAndLog(e);
     final ErrorResponse response = ErrorResponse.of(GlobalErrorCode.INVALID_INPUT_VALUE);
     return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
   }
@@ -43,18 +54,21 @@ public class GlobalControllerAdvice {
   @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
   protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
       HttpRequestMethodNotSupportedException e) {
+    countExceptionAndLog(e);
     final ErrorResponse response = ErrorResponse.of(GlobalErrorCode.METHOD_NOT_ALLOWED);
     return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
   }
 
   @ExceptionHandler(AccessDeniedException.class)
   protected ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
+    countExceptionAndLog(e);
     final ErrorResponse response = ErrorResponse.of(GlobalErrorCode.HANDLE_ACCESS_DENIED);
     return new ResponseEntity<>(response, HttpStatus.valueOf(GlobalErrorCode.HANDLE_ACCESS_DENIED.getStatus()));
   }
 
   @ExceptionHandler(BusinessException.class)
   protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
+    countExceptionAndLog(e);
     ErrorCode errorCode = e.getErrorCode();
     final ErrorResponse response = ErrorResponse.of(errorCode);
     return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
@@ -62,15 +76,20 @@ public class GlobalControllerAdvice {
 
   @ExceptionHandler(JsonParseException.class)
   protected ResponseEntity<ErrorResponse> handleJsonParseException(final JsonParseException e) {
-    e.printStackTrace();
+    countExceptionAndLog(e);
     final ErrorResponse response = ErrorResponse.of(GlobalErrorCode.INVALID_JSON_INPUT);
     return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
   }
 
   @ExceptionHandler(InvalidFormatException.class)
   protected ResponseEntity<ErrorResponse> handleInvalidFormatException(final InvalidFormatException e) {
-    e.printStackTrace();
+    countExceptionAndLog(e);
     final ErrorResponse response = ErrorResponse.of(GlobalErrorCode.INVALID_ENUM_INPUT);
     return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+  }
+
+  private void countExceptionAndLog(final Exception e) {
+    logger.error(e.getClass().getSimpleName(), e.getMessage());
+    logger.debug(e.getClass().getSimpleName(), e.getMessage(), e);
   }
 }

--- a/src/main/java/com/se/apiserver/v1/common/presentation/response/ExceptionResponse.java
+++ b/src/main/java/com/se/apiserver/v1/common/presentation/response/ExceptionResponse.java
@@ -1,11 +1,10 @@
-package com.se.apiserver.v1.common.application.dto;
+package com.se.apiserver.v1.common.presentation.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 
 public class ExceptionResponse {
 
@@ -29,6 +28,12 @@ public class ExceptionResponse {
 
   public static ExceptionResponse of(Exception e) {
     return new ExceptionResponse(e);
+  }
+
+  public static ExceptionResponse of(Exception e, String message) {
+    ExceptionResponse exceptionResponse = new ExceptionResponse(e);
+    exceptionResponse.message = message;
+    return exceptionResponse;
   }
 
   private List<FieldError> initErrors(List<FieldError> errors) {

--- a/src/main/java/com/se/apiserver/v1/common/presentation/response/SuccessResponse.java
+++ b/src/main/java/com/se/apiserver/v1/common/presentation/response/SuccessResponse.java
@@ -1,4 +1,4 @@
-package com.se.apiserver.v1.common.application.dto;
+package com.se.apiserver.v1.common.presentation.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="60 seconds">
+
+  <!--로그 파일 저장 위치-->
+  <property name="LOGS_PATH" value="./logs"/>
+
+  <!--출력 정보 설정-->
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <Pattern>%d{HH:mm} %-5level %logger{36} - %msg%n</Pattern>
+    </layout>
+  </appender>
+
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOGS_PATH}/logback.log</file>
+    <encoder>
+      <charset>UTF-8</charset>
+      <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][%thread] %-5level %logger{35} - %msg%n</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${LOGS_PATH}/logback.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+      <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+        <!-- or whenever the file size reaches 100MB -->
+        <maxFileSize>10MB</maxFileSize>
+        <!-- kb, mb, gb -->
+      </timeBasedFileNamingAndTriggeringPolicy>
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+  </appender>
+
+  <!--출력 프로필 설정-->
+  <!--로컬 환경인 경우, 콘솔에만 출력-->
+  <springProfile name="local">
+    <root level="INFO">
+      <appender-ref ref="CONSOLE" />
+    </root>
+  </springProfile>
+
+  <!--배포 환경인 경우, 콘솔 + 파일 출력 -->
+  <springProfile name="prod">
+    <root level="INFO">
+      <appender-ref ref="CONSOLE" />
+      <appender-ref ref="FILE" />
+    </root>
+  </springProfile>
+
+
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -44,5 +44,20 @@
     </root>
   </springProfile>
 
+  <!--로컬 DEBUG 환경 : Stacktrace -->
+  <springProfile name="local-debug">
+    <root level="DEBUG">
+      <appender-ref ref="CONSOLE" />
+    </root>
+  </springProfile>
+
+  <!--배포 DEBUG 환경 : Stacktrace -->
+  <springProfile name="prod-debug">
+    <root level="DEBUG">
+      <appender-ref ref="CONSOLE" />
+      <appender-ref ref="FILE" />
+    </root>
+  </springProfile>
+
 
 </configuration>


### PR DESCRIPTION
# Pull Request Check List
- Major Reviewer: @KitTeamSe/be 

## CheckList

- [ ] Unit test coverage
- [ ] Backward compatibility
- [ ] Tested on dev/staging environment
- [ ] Documentation
- [x] Self reviewed

## Context
### Logging
- common/infra에 logging 패키지 추가
  SeLogger 인터페이스 및 SeStandardLogger 추가
- SeExceptionAdvice와 GlobalControllerAdvice의 로깅 코드 추가. 
  GlobalControllerAdvice에서 처리하지 않는 예외만 SeExceptionAdvice에서 처리하게 하였음.
- .gitignore에 log폴더 제외
- logback 사용을 위한 xml 파일을 resource에 추가.
- yml 파일 업데이트 필요. 

### Refactor
- SuccessResponse, ExceptionResponse를 application 레이어에서 presentation 레이어로 이동
- BaseRequest 패키지 이동(common/application/dto/request)

### Next
현재는 GlobalControllerAdvice와 SeExceptionAdvice를 혼용해서 사용. 
GlobalControllerAdvice와 ErrorResponse가 사용되는 도메인이 너무 커 수정하면 충돌이 많이 발생할 것으로 보임.
따라서 GlobalControllerAdvice에서 처리하지 않는 예외만 SeExceptionAdvice에서 처리하도록 하였음.
추후 의논 후 GlobalControllerAdvice를 수정해서 사용하든, SeExceptionAdvice로 넘어가든 해야할 듯.