### PR TITLE
[KIT-121] 게시판 삭제 시 연관 관계 엔티티 fk null 처리

### DIFF
--- a/src/main/java/com/se/apiserver/v1/board/application/service/BoardDeleteService.java
+++ b/src/main/java/com/se/apiserver/v1/board/application/service/BoardDeleteService.java
@@ -20,9 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class BoardDeleteService {
 
-    @Value("${spring.deletedBoard}")
-    private String DELETEDBOARD;
-
     private final BoardJpaRepository boardJpaRepository;
     private final AccountContextService accountContextService;
     private final PostJpaRepository postJpaRepository;
@@ -32,11 +29,10 @@ public class BoardDeleteService {
         Set<String> authoritySet = accountContextService.getContextAuthorities();
 
         Board board = boardJpaRepository.findById(id).orElseThrow(() -> new BusinessException(BoardErrorCode.NO_SUCH_BOARD));
-        Optional<Board> deletedBoard = boardJpaRepository.findByNameEng("deletedBoard");
 
         List<Post> postList = postJpaRepository.findAllByBoard(board);
         for(Post post: postList){
-            post.delete(authoritySet, deletedBoard.get());
+            post.delete(authoritySet);
         }
         postJpaRepository.saveAll(postList);
         boardJpaRepository.delete(board);

--- a/src/main/java/com/se/apiserver/v1/post/domain/entity/Post.java
+++ b/src/main/java/com/se/apiserver/v1/post/domain/entity/Post.java
@@ -33,7 +33,7 @@ public class Post extends BaseEntity {
   private Long postId;
 
   @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
-  @JoinColumn(name = "board_id", referencedColumnName = "boardId", nullable = false)
+  @JoinColumn(name = "board_id", referencedColumnName = "boardId")
   private Board board;
 
   @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
@@ -242,10 +242,10 @@ public class Post extends BaseEntity {
     delete();
   }
 
-  public void delete(Set<String> authorities, Board deletedBoard) {
+  public void delete(Set<String> authorities) {
     validateAccountAccess(authorities);
     delete();
-    this.board = deletedBoard;
+    this.board = null;
   }
 
   public void delete() {

--- a/src/test/java/com/se/apiserver/v1/board/application/service/BoardDeleteServiceTest.java
+++ b/src/test/java/com/se/apiserver/v1/board/application/service/BoardDeleteServiceTest.java
@@ -79,13 +79,10 @@ class BoardDeleteServiceTest {
     //Given
     BoardDeleteDto.Request request = createBoardDeleteRequest();
     Board board = new Board("freeboard","자유게시판");
-    Board deletedBoard = new Board("deletedBoard","삭제된 게시판");
 
     Long fakeBoardId = 1L;
     ReflectionTestUtils.setField(board,"boardId", fakeBoardId);
 
-    Long fakeDeletedBoardId = 2L;
-    ReflectionTestUtils.setField(deletedBoard,"boardId", fakeDeletedBoardId);
 
     Account account = createAccount();
     Set<String> authorities = Set.of("MENU_MANAGE");
@@ -97,7 +94,6 @@ class BoardDeleteServiceTest {
     ReflectionTestUtils.setField(post,"postId", fakePostId);
 
     when(boardJpaRepository.findById(fakeBoardId)).thenReturn(Optional.ofNullable(board));
-    when(boardJpaRepository.findByNameEng("deletedBoard")).thenReturn(Optional.ofNullable(deletedBoard));
     when(postJpaRepository.findAllByBoard(board)).thenReturn(postList);
     when(postJpaRepository.findById(fakePostId)).thenReturn(Optional.of(post));
     when(accountContextService.getContextAuthorities()).thenReturn(authorities);
@@ -107,7 +103,7 @@ class BoardDeleteServiceTest {
 
     Optional<Post> findPost = postJpaRepository.findById(fakePostId);
     assertThat(result).isEqualTo(true);
-    assertThat(findPost.get().getBoard().getNameEng()).isEqualTo(deletedBoard.getNameEng());
+    assertThat(findPost.get().getBoard()).isEqualTo(null);
     assertThat(findPost.get().getPostIsDeleted()).isEqualTo(PostIsDeleted.DELETED);
   }
 
@@ -133,13 +129,8 @@ class BoardDeleteServiceTest {
     //Given
     BoardDeleteDto.Request request = createBoardDeleteRequest();
     Board board = new Board("freeboard","자유게시판");
-    Board deletedBoard = new Board("deletedBoard","삭제된 게시판");
-
     Long fakeBoardId = 1L;
     ReflectionTestUtils.setField(board,"boardId", fakeBoardId);
-
-    Long fakeDeletedBoardId = 2L;
-    ReflectionTestUtils.setField(deletedBoard,"boardId", fakeDeletedBoardId);
 
     Set<String> authorities = Set.of("");
 
@@ -153,7 +144,6 @@ class BoardDeleteServiceTest {
 
     when(accountContextService.getContextAuthorities()).thenReturn(authorities);
     when(boardJpaRepository.findById(fakeBoardId)).thenReturn(Optional.ofNullable(board));
-    when(boardJpaRepository.findByNameEng("deletedBoard")).thenReturn(Optional.ofNullable(deletedBoard));
     when(postJpaRepository.findAllByBoard(board)).thenReturn(postList);
 
     //When


### PR DESCRIPTION
# Pull Request Check List
- Major Reviewer: @KitTeamSe/be 

## CheckList

- [ ] Unit test coverage
- [ ] Backward compatibility
- [ ] Tested on dev/staging environment
- [ ] Documentation
- [ ] Self reviewed

## Context

**PLEASE FILL THIS PAGE**

board 삭제 시, 연관관계 있는 Post에 null 값 넣습니다.

늦어서 죄송합니다 가족 중 한 명이 코로나 확진자랑 접촉되셔서 그분 케어한다고 몇 주간 집중 못했습니다 ㅜㅜ