### PR TITLE
[KIT-201] 댓글 Read DTO Fix

### DIFF
--- a/src/main/java/com/se/apiserver/v1/common/infra/dto/ErrorResponse.java
+++ b/src/main/java/com/se/apiserver/v1/common/infra/dto/ErrorResponse.java
@@ -52,9 +52,19 @@ public class ErrorResponse {
         .map(error -> ErrorResponse.FieldError.builder()
             .reason(error.getDefaultMessage())
             .field(error.getField())
-            .value((String) error.getRejectedValue())
+            .value(getRejectedValue(error))
             .build())
         .collect(Collectors.toList());
+  }
+
+  private static String getRejectedValue(org.springframework.validation.FieldError error){
+    Object rejectedValue = error.getRejectedValue();
+    try{
+      return String.valueOf(rejectedValue);
+    }
+    catch (Exception e){
+      return "";
+    }
   }
 
   @Getter

--- a/src/main/java/com/se/apiserver/v1/common/presentation/response/ExceptionResponse.java
+++ b/src/main/java/com/se/apiserver/v1/common/presentation/response/ExceptionResponse.java
@@ -44,8 +44,18 @@ public class ExceptionResponse {
     final List<org.springframework.validation.FieldError> errors = bindingResult.getFieldErrors();
     return errors.parallelStream()
         .map(error ->
-            new FieldError(error.getField(), (String) error.getRejectedValue(), error.getDefaultMessage()))
+            new FieldError(error.getField(), getRejectedValue(error), error.getDefaultMessage()))
         .collect(Collectors.toList());
+  }
+
+  private static String getRejectedValue(org.springframework.validation.FieldError error){
+    Object rejectedValue = error.getRejectedValue();
+    try{
+      return String.valueOf(rejectedValue);
+    }
+    catch (Exception e){
+      return "";
+    }
   }
 
   public String getMessage() {

--- a/src/main/java/com/se/apiserver/v1/reply/application/dto/ReplyCreateDto.java
+++ b/src/main/java/com/se/apiserver/v1/reply/application/dto/ReplyCreateDto.java
@@ -44,7 +44,7 @@ public class ReplyCreateDto {
     private Anonymous anonymous;
 
     @Min(1)
-    @ApiModelProperty(notes = "부모 댓글의 번호")
+    @ApiModelProperty(notes = "부모 댓글의 번호", example = "1")
     private Long parentId;
 
     @ApiModelProperty(notes = "비밀 여부")

--- a/src/main/java/com/se/apiserver/v1/reply/application/dto/ReplyCreateDto.java
+++ b/src/main/java/com/se/apiserver/v1/reply/application/dto/ReplyCreateDto.java
@@ -7,9 +7,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.List;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Singular;
@@ -22,7 +20,7 @@ public class ReplyCreateDto {
   @ApiModel(value = "댓글 생성 요청")
   public static class Request {
 
-    public Request(Long postId, String text, Anonymous anonymous, Long parentId, ReplyIsSecret isSecret, List<AttachDto> attachmentList) {
+    public Request(Long postId, String text, Anonymous anonymous, Long parentId, ReplyIsSecret isSecret, List<ReplyCreateAttachDto> attachmentList) {
       this.postId = postId;
       this.text = text;
       this.anonymous = anonymous;
@@ -53,16 +51,16 @@ public class ReplyCreateDto {
 
     @ApiModelProperty(notes = "첨부파일들")
     @Singular("attachmentList")
-    private List<AttachDto> attachmentList;
+    private List<ReplyCreateAttachDto> attachmentList;
   }
 
   @Getter
   @NoArgsConstructor
   @Builder
-  public static class AttachDto {
+  public static class ReplyCreateAttachDto {
     private Long attachId;
 
-    public AttachDto(Long attachId) {
+    public ReplyCreateAttachDto(Long attachId) {
       this.attachId = attachId;
     }
   }

--- a/src/main/java/com/se/apiserver/v1/reply/application/dto/ReplyReadDto.java
+++ b/src/main/java/com/se/apiserver/v1/reply/application/dto/ReplyReadDto.java
@@ -30,7 +30,7 @@ public class ReplyReadDto {
     private String text;
     private String accountId;
     private String anonymousNickname;
-    private List<AttachDto> attacheList;
+    private List<ReplyReadAttachDto> attacheList;
     private List<Response> child;
     private LocalDateTime createAt;
     private ReplyIsSecret isSecret;
@@ -58,8 +58,8 @@ public class ReplyReadDto {
         responseBuilder.parentId(reply.getParent().getReplyId());
       }
 
-      List<AttachDto> attaches = reply.getAttaches().stream()
-          .map(attach -> new AttachDto(attach.getAttachId(), attach.getDownloadUrl(), attach.getFileName(), attach.getFileSize()))
+      List<ReplyReadAttachDto> attaches = reply.getAttaches().stream()
+          .map(attach -> new ReplyReadAttachDto(attach.getAttachId(), attach.getDownloadUrl(), attach.getFileName(), attach.getFileSize()))
           .collect(Collectors.toList());
       responseBuilder.attacheList(attaches);
       responseBuilder.createAt(reply.getCreatedAt());
@@ -89,13 +89,13 @@ public class ReplyReadDto {
 
     @Getter
     @NoArgsConstructor
-    public static class AttachDto {
+    public static class ReplyReadAttachDto {
       private Long attachId;
       private String downloadUrl;
       private String fileName;
       private Long fileSize;
 
-      public AttachDto(Long attachId, String downloadUrl, String fileName, Long fileSize) {
+      public ReplyReadAttachDto(Long attachId, String downloadUrl, String fileName, Long fileSize) {
         this.attachId = attachId;
         this.downloadUrl = downloadUrl;
         this.fileName = fileName;

--- a/src/main/java/com/se/apiserver/v1/reply/application/dto/ReplyUpdateDto.java
+++ b/src/main/java/com/se/apiserver/v1/reply/application/dto/ReplyUpdateDto.java
@@ -7,7 +7,6 @@ import java.util.List;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Singular;
@@ -21,7 +20,7 @@ public class ReplyUpdateDto {
 
         public Request(Long replyId, String password, String text,
             ReplyIsSecret isSecret,
-            List<AttachDto> attachmentList) {
+            List<ReplyUpdateAttachDto> attachmentList) {
             this.replyId = replyId;
             this.password = password;
             this.text = text;
@@ -47,16 +46,16 @@ public class ReplyUpdateDto {
 
         @ApiModelProperty(notes = "첨부파일들")
         @Singular("attachmentList")
-        private List<AttachDto> attachmentList;
+        private List<ReplyUpdateAttachDto> attachmentList;
     }
 
     @Getter
     @NoArgsConstructor
     @Builder
-    public static class AttachDto {
+    public static class ReplyUpdateAttachDto {
         private Long attachId;
 
-        public AttachDto(Long attachId) {
+        public ReplyUpdateAttachDto(Long attachId) {
             this.attachId = attachId;
         }
     }

--- a/src/main/java/com/se/apiserver/v1/reply/application/dto/ReplyUpdateDto.java
+++ b/src/main/java/com/se/apiserver/v1/reply/application/dto/ReplyUpdateDto.java
@@ -19,12 +19,11 @@ public class ReplyUpdateDto {
     @ApiModel(value = "댓글 수정 요청")
     public static class Request{
 
-        public Request(Long replyId, String password, Long postId, String text,
+        public Request(Long replyId, String password, String text,
             ReplyIsSecret isSecret,
             List<AttachDto> attachmentList) {
             this.replyId = replyId;
             this.password = password;
-            this.postId = postId;
             this.text = text;
             this.isSecret = isSecret;
             this.attachmentList = attachmentList;
@@ -37,11 +36,6 @@ public class ReplyUpdateDto {
 
         @ApiModelProperty(notes = "익명 댓글 비밀번호", example = "string")
         private String password;
-
-        @NotNull
-        @Min(1)
-        @ApiModelProperty(notes = "게시글 아이디", example = "1")
-        private Long postId;
 
         @NotNull
         @ApiModelProperty(notes = "댓글 내용", example = "string")

--- a/src/main/java/com/se/apiserver/v1/reply/application/service/ReplyCreateService.java
+++ b/src/main/java/com/se/apiserver/v1/reply/application/service/ReplyCreateService.java
@@ -10,6 +10,7 @@ import com.se.apiserver.v1.post.application.error.PostErrorCode;
 import com.se.apiserver.v1.post.domain.entity.Post;
 import com.se.apiserver.v1.post.infra.repository.PostJpaRepository;
 import com.se.apiserver.v1.reply.application.dto.ReplyCreateDto;
+import com.se.apiserver.v1.reply.application.dto.ReplyCreateDto.ReplyCreateAttachDto;
 import com.se.apiserver.v1.reply.application.error.ReplyErrorCode;
 import com.se.apiserver.v1.reply.domain.entity.Reply;
 import com.se.apiserver.v1.reply.domain.entity.ReplyIsDelete;
@@ -101,7 +102,7 @@ public class ReplyCreateService {
     }
   }
 
-  private List<Attach> getAttaches(List<ReplyCreateDto.AttachDto> attachmentList) {
+  private List<Attach> getAttaches(List<ReplyCreateAttachDto> attachmentList) {
     if(attachmentList == null || attachmentList.size() == 0)
       return new ArrayList<>();
     return attachmentList.stream()

--- a/src/main/java/com/se/apiserver/v1/reply/application/service/ReplyUpdateService.java
+++ b/src/main/java/com/se/apiserver/v1/reply/application/service/ReplyUpdateService.java
@@ -5,10 +5,9 @@ import com.se.apiserver.v1.attach.application.error.AttachErrorCode;
 import com.se.apiserver.v1.attach.domain.entity.Attach;
 import com.se.apiserver.v1.attach.infra.repository.AttachJpaRepository;
 import com.se.apiserver.v1.common.domain.exception.BusinessException;
-import com.se.apiserver.v1.post.application.error.PostErrorCode;
 import com.se.apiserver.v1.post.domain.entity.Post;
-import com.se.apiserver.v1.post.infra.repository.PostJpaRepository;
 import com.se.apiserver.v1.reply.application.dto.ReplyUpdateDto;
+import com.se.apiserver.v1.reply.application.dto.ReplyUpdateDto.ReplyUpdateAttachDto;
 import com.se.apiserver.v1.reply.application.error.ReplyErrorCode;
 import com.se.apiserver.v1.reply.domain.entity.Reply;
 import com.se.apiserver.v1.reply.domain.entity.ReplyIsSecret;
@@ -98,7 +97,7 @@ public class ReplyUpdateService {
     }
   }
 
-  private List<Attach> getAttaches(List<ReplyUpdateDto.AttachDto> attachmentList) {
+  private List<Attach> getAttaches(List<ReplyUpdateAttachDto> attachmentList) {
     if(attachmentList == null || attachmentList.size() == 0)
       return new ArrayList<>();
     return attachmentList.stream()

--- a/src/main/java/com/se/apiserver/v1/reply/application/service/ReplyUpdateService.java
+++ b/src/main/java/com/se/apiserver/v1/reply/application/service/ReplyUpdateService.java
@@ -26,19 +26,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReplyUpdateService {
 
   private ReplyJpaRepository replyJpaRepository;
-  private PostJpaRepository postJpaRepository;
   private AccountContextService accountContextService;
   private PasswordEncoder passwordEncoder;
   private AttachJpaRepository attachJpaRepository;
 
   public ReplyUpdateService(
       ReplyJpaRepository replyJpaRepository,
-      PostJpaRepository postJpaRepository,
       AccountContextService accountContextService,
       PasswordEncoder passwordEncoder,
       AttachJpaRepository attachJpaRepository) {
     this.replyJpaRepository = replyJpaRepository;
-    this.postJpaRepository = postJpaRepository;
     this.accountContextService = accountContextService;
     this.passwordEncoder = passwordEncoder;
     this.attachJpaRepository = attachJpaRepository;
@@ -48,8 +45,7 @@ public class ReplyUpdateService {
   public Long update(ReplyUpdateDto.Request request) {
     Reply reply = replyJpaRepository.findById(request.getReplyId())
         .orElseThrow(() -> new BusinessException(ReplyErrorCode.NO_SUCH_REPLY));
-    Post post = postJpaRepository.findById(request.getPostId())
-        .orElseThrow(() -> new BusinessException(PostErrorCode.NO_SUCH_POST));
+    Post post = reply.getPost();
 
     post.validateReadable();
     post.getBoard().validateAccessAuthority(accountContextService.getContextAuthorities());

--- a/src/test/java/com/se/apiserver/v1/reply/application/service/ReplyCreateServiceTest.java
+++ b/src/test/java/com/se/apiserver/v1/reply/application/service/ReplyCreateServiceTest.java
@@ -13,10 +13,7 @@ import com.se.apiserver.v1.account.domain.entity.Account;
 import com.se.apiserver.v1.account.domain.entity.AccountType;
 import com.se.apiserver.v1.account.domain.entity.InformationOpenAgree;
 import com.se.apiserver.v1.account.domain.entity.Question;
-import com.se.apiserver.v1.attach.application.dto.AttachReadDto;
-import com.se.apiserver.v1.attach.application.service.AttachCreateService;
 import com.se.apiserver.v1.attach.domain.entity.Attach;
-import com.se.apiserver.v1.attach.infra.repository.AttachJpaRepository;
 import com.se.apiserver.v1.board.domain.entity.Board;
 import com.se.apiserver.v1.common.domain.entity.Anonymous;
 import com.se.apiserver.v1.common.domain.exception.BusinessException;
@@ -27,7 +24,6 @@ import com.se.apiserver.v1.post.domain.entity.PostIsNotice;
 import com.se.apiserver.v1.post.domain.entity.PostIsSecret;
 import com.se.apiserver.v1.post.infra.repository.PostJpaRepository;
 import com.se.apiserver.v1.reply.application.dto.ReplyCreateDto;
-import com.se.apiserver.v1.reply.application.dto.ReplyCreateDto.AttachDto;
 import com.se.apiserver.v1.reply.application.dto.ReplyCreateDto.Request;
 import com.se.apiserver.v1.reply.application.error.ReplyErrorCode;
 import com.se.apiserver.v1.reply.domain.entity.Reply;
@@ -50,7 +46,6 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
 public class ReplyCreateServiceTest {

--- a/src/test/java/com/se/apiserver/v1/reply/application/service/ReplyUpdateServiceTest.java
+++ b/src/test/java/com/se/apiserver/v1/reply/application/service/ReplyUpdateServiceTest.java
@@ -63,13 +63,11 @@ public class ReplyUpdateServiceTest {
   @Test
   void 익명_댓글_수정_성공() {
     // given
-    Long postId = 1L;
     Long replyId = 1L;
     ReplyUpdateDto.Request request = ReplyUpdateDto.Request
         .builder()
         .replyId(replyId)
         .password("1234")
-        .postId(postId)
         .text("댓글댓글댓글댓글댓글")
         .isSecret(ReplyIsSecret.NORMAL)
         .build();
@@ -86,7 +84,6 @@ public class ReplyUpdateServiceTest {
     Set<String> authorities = new HashSet<>(Arrays.asList("FREEBOARD_ACCESS"));
 
     given(replyJpaRepository.findById(replyId)).willReturn(java.util.Optional.of(reply));
-    given(postJpaRepository.findById(postId)).willReturn(java.util.Optional.of(post));
     given(accountContextService.getContextAuthorities()).willReturn(authorities);
     given(
         passwordEncoder.matches(request.getPassword(), reply.getAnonymous().getAnonymousPassword()))
@@ -101,13 +98,11 @@ public class ReplyUpdateServiceTest {
   @Test
   void 회원_댓글_수정_성공() {
     // given
-    Long postId = 1L;
     Long replyId = 1L;
     ReplyUpdateDto.Request request = ReplyUpdateDto.Request
         .builder()
         .replyId(replyId)
         .password("1234")
-        .postId(postId)
         .text("댓글댓글댓글댓글댓글")
         .isSecret(ReplyIsSecret.NORMAL)
         .build();
@@ -121,11 +116,9 @@ public class ReplyUpdateServiceTest {
         , "127.0.0.1"
         , account);
     Reply savedReply = reply;
-    MultipartFile[] files = new MultipartFile[1];
     Set<String> authorities = new HashSet<>(Arrays.asList("FREEBOARD_ACCESS"));
 
     given(replyJpaRepository.findById(replyId)).willReturn(java.util.Optional.of(reply));
-    given(postJpaRepository.findById(postId)).willReturn(java.util.Optional.of(post));
     given(accountContextService.getContextAuthorities()).willReturn(authorities);
     given(accountContextService.getCurrentAccountId()).willReturn(account.getAccountId());
     given(replyJpaRepository.save(reply)).willReturn(reply);
@@ -145,7 +138,6 @@ public class ReplyUpdateServiceTest {
         .builder()
         .replyId(replyId)
         .password("1234")
-        .postId(postId)
         .text("댓글댓글댓글댓글댓글")
         .isSecret(ReplyIsSecret.NORMAL)
         .build();
@@ -159,7 +151,6 @@ public class ReplyUpdateServiceTest {
         , null
         , "127.0.0.1"
         , account);
-    MultipartFile[] files = new MultipartFile[1];
     List<AttachReadDto.Response> dtoResponse
         = new ArrayList<>(Arrays.asList(
         AttachReadDto.Response
@@ -171,7 +162,6 @@ public class ReplyUpdateServiceTest {
     Set<String> authorities = new HashSet<>(Arrays.asList("FREEBOARD_ACCESS"));
 
     given(replyJpaRepository.findById(replyId)).willReturn(java.util.Optional.of(reply));
-    given(postJpaRepository.findById(postId)).willReturn(java.util.Optional.of(post));
     given(accountContextService.getContextAuthorities()).willReturn(authorities);
     given(accountContextService.getCurrentAccountId()).willReturn(anotherAccountId);
 
@@ -192,7 +182,6 @@ public class ReplyUpdateServiceTest {
         .builder()
         .replyId(replyId)
         .password("1234")
-        .postId(postId)
         .text("댓글댓글댓글댓글댓글")
         .isSecret(ReplyIsSecret.NORMAL)
         .build();
@@ -211,52 +200,13 @@ public class ReplyUpdateServiceTest {
   }
 
   @Test
-  void 존재하지_않는_게시글() {
-    // given
-    Long replyId = 1L;
-    Long nonExistentPostId = 2L;
-    ReplyUpdateDto.Request request = ReplyUpdateDto.Request
-        .builder()
-        .replyId(replyId)
-        .password("1234")
-        .postId(nonExistentPostId)
-        .text("댓글댓글댓글댓글댓글")
-        .isSecret(ReplyIsSecret.NORMAL)
-
-        .build();
-    Post post = getPost();
-    Reply reply = new Reply(post
-        , request.getText()
-        , request.getIsSecret()
-        , null
-        , null
-        , "127.0.0.1"
-        , getAnonymous());
-
-    given(replyJpaRepository.findById(replyId)).willReturn(Optional.of(reply));
-    given(postJpaRepository.findById(nonExistentPostId))
-        .willThrow(new BusinessException(PostErrorCode.NO_SUCH_POST));
-
-    // when
-    BusinessException businessException = assertThrows(BusinessException.class,
-        () -> replyUpdateService
-            .update(request));
-
-    // then
-    assertThat(businessException.getErrorCode(), is(PostErrorCode.NO_SUCH_POST));
-    assertThat(businessException.getMessage(), is("존재하지 않는 게시글"));
-  }
-
-  @Test
   void 익명_댓글_비밀번호_불일치() {
     // given
-    Long postId = 1L;
     Long replyId = 1L;
     ReplyUpdateDto.Request request = ReplyUpdateDto.Request
         .builder()
         .replyId(replyId)
         .password("wrong")
-        .postId(postId)
         .text("댓글댓글댓글댓글댓글")
         .isSecret(ReplyIsSecret.NORMAL)
 
@@ -273,7 +223,6 @@ public class ReplyUpdateServiceTest {
     Set<String> authorities = new HashSet<>(Arrays.asList("FREEBOARD_ACCESS"));
 
     given(replyJpaRepository.findById(replyId)).willReturn(java.util.Optional.of(reply));
-    given(postJpaRepository.findById(postId)).willReturn(java.util.Optional.of(post));
     given(accountContextService.getContextAuthorities()).willReturn(authorities);
     given(
         passwordEncoder.matches(request.getPassword(), reply.getAnonymous().getAnonymousPassword()))


### PR DESCRIPTION
# Pull Request Check List
- Major Reviewer: @KitTeamSe/be 

## CheckList

- [ ] Unit test coverage
- [ ] Backward compatibility
- [ ] Tested on dev/staging environment
- [ ] Documentation
- [x] Self reviewed

## Context
- 댓글 Update DTO에서 PostID를 제외하였습니다.
- ErrorResponse에서 FieldError 생성시 String Converting 도중 예외가 발생해서, 예외 메시지가 제대로 만들어지지 않는 버그 픽스.
- Swagger 댓글 Create, Update에 Attach DTO가 올바르게 표시되지 않는 버그 픽스. ReplyReadDTO 안의 AttachDTO가 표시되고 있어, 네이밍을 각자 다르게 변경하였음.