### PR TITLE
[KIT-259] 익명 비밀 게시글 조회 시 관리자인 경우 비밀번호 없이 조회 가능하게 수정.

### DIFF
--- a/src/main/java/com/se/apiserver/v1/post/application/service/PostReadService.java
+++ b/src/main/java/com/se/apiserver/v1/post/application/service/PostReadService.java
@@ -11,7 +11,6 @@ import com.se.apiserver.v1.post.application.dto.PostReadDto.PostSearchRequest;
 import com.se.apiserver.v1.post.domain.entity.Post;
 import com.se.apiserver.v1.post.application.error.PostErrorCode;
 import com.se.apiserver.v1.post.domain.entity.PostIsNotice;
-import com.se.apiserver.v1.post.domain.entity.PostIsSecret;
 import com.se.apiserver.v1.post.application.dto.PostReadDto;
 import com.se.apiserver.v1.post.domain.repository.PostRepositoryProtocol;
 import com.se.apiserver.v1.post.infra.repository.PostJpaRepository;
@@ -128,6 +127,8 @@ public class PostReadService {
   }
 
   private void validateAnonymousPostPassword(Post post, String password) {
+    if(isOwnerOrHasManageAuthority(post))
+      return;
     if (!passwordEncoder.matches(password, post.getAnonymousPassword())) {
       throw new BusinessException(PostErrorCode.ANONYMOUS_PASSWORD_INCORRECT);
     }
@@ -136,14 +137,8 @@ public class PostReadService {
 
   private boolean isOwnerOrHasManageAuthority(Post post) {
     Set<String> authorities = accountContextService.getContextAuthorities();
-    if (post.getAccount() == null) {
-      return post.getIsSecret() == PostIsSecret.NORMAL;
-    }
-    if (authorities.contains(Post.MANAGE_AUTHORITY) || post
-        .isOwner(accountContextService.getCurrentAccountId())) {
-      return true;
-    }
-    return false;
+    return authorities.contains(Post.MANAGE_AUTHORITY) || post
+        .isOwner(accountContextService.getCurrentAccountId());
   }
 
 

--- a/src/main/java/com/se/apiserver/v1/post/domain/entity/Post.java
+++ b/src/main/java/com/se/apiserver/v1/post/domain/entity/Post.java
@@ -229,14 +229,14 @@ public class Post extends BaseEntity {
   }
 
   public boolean isOwner(Account contextAccount) {
-    if (this.account == contextAccount) {
+    if (this.account != null && this.account == contextAccount) {
       return true;
     }
     return false;
   }
 
   public boolean isOwner(Long accountId) {
-    if (this.account.getAccountId() == accountId) {
+    if (this.account != null && this.account.getAccountId().equals(accountId)) {
       return true;
     }
     return false;


### PR DESCRIPTION
# Pull Request Check List
- Major Reviewer: @KitTeamSe/be 

## CheckList

- [ ] Unit test coverage
- [ ] Backward compatibility
- [ ] Tested on dev/staging environment
- [ ] Documentation
- [x] Self reviewed

## Context
- 익명 비밀글의 경우 isOwner 메소드 호출 시 false 반환하게 수정. (익명 게시글은 주인을 검증할 수 없으므로)
- 위 로직을 서비스 로직에서 도메인 로직으로 변경
- 익명 비밀글의 비밀번호 체크 로직은 관리자인 경우 수행하지 않도록 하였음.